### PR TITLE
Add install target to consume the library through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,45 +78,58 @@ if(DINGO_DEVELOPMENT_MODE)
         /wd4702 # unreachable code
     )
 
+    set(DINGO_SOURCE_FILES
+        allocator.h
+        annotated.h
+        arena_allocator.h
+        class_instance_factory.h
+        class_instance_factory_i.h
+        class_instance_factory_traits.h
+        class_instance_resolver.h
+        class_instance_temporary.h
+        class_traits.h
+        collection_traits.h
+        config.h
+        constructor.h
+        container.h
+        decay.h
+        exceptions.h
+        factory/callable.h
+        factory/constructor.h
+        factory/function.h
+        index/array.h
+        index/map.h
+        index/unordered_map.h
+        index.h
+        rebind_type.h
+        resettable_i.h
+        resolving_context.h
+        rtti/static_type_info.h
+        rtti/typeid_type_info.h
+        storage.h
+        storage/external.h
+        storage/shared.h
+        storage/shared_cyclical.h
+        storage/unique.h
+        type_cache.h
+        type_conversion.h
+        type_list.h
+        type_map.h
+        type_registration.h
+        type_traits.h
+    )
+
+    set(DINGO_INTERFACE_SOURCES "")
+    foreach(FILE ${DINGO_SOURCE_FILES})
+        list(
+            APPEND DINGO_INTERFACE_SOURCES
+                "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/dingo/${FILE}>"
+                "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dingo/${FILE}>"
+        )
+    endforeach()
+
     target_sources(dingo INTERFACE
-        include/dingo/allocator.h
-        include/dingo/annotated.h
-        include/dingo/arena_allocator.h
-        include/dingo/class_instance_factory.h
-        include/dingo/class_instance_factory_i.h
-        include/dingo/class_instance_factory_traits.h
-        include/dingo/class_instance_resolver.h
-        include/dingo/class_instance_temporary.h
-        include/dingo/class_traits.h
-        include/dingo/collection_traits.h
-        include/dingo/config.h
-        include/dingo/constructor.h
-        include/dingo/container.h
-        include/dingo/decay.h
-        include/dingo/exceptions.h
-        include/dingo/factory/callable.h
-        include/dingo/factory/constructor.h
-        include/dingo/factory/function.h
-        include/dingo/index/array.h
-        include/dingo/index/map.h
-        include/dingo/index/unordered_map.h
-        include/dingo/index.h
-        include/dingo/rebind_type.h
-        include/dingo/resettable_i.h
-        include/dingo/resolving_context.h
-        include/dingo/rtti/static_type_info.h
-        include/dingo/rtti/typeid_type_info.h
-        include/dingo/storage.h
-        include/dingo/storage/external.h
-        include/dingo/storage/shared.h
-        include/dingo/storage/shared_cyclical.h
-        include/dingo/storage/unique.h
-        include/dingo/type_cache.h
-        include/dingo/type_conversion.h
-        include/dingo/type_list.h
-        include/dingo/type_map.h
-        include/dingo/type_registration.h
-        include/dingo/type_traits.h
+        ${DINGO_INTERFACE_SOURCES}
     )
 
     if(DINGO_TESTING_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,32 @@
 cmake_minimum_required(VERSION 3.19)
 project(dingo)
 
+include(GNUInstallDirs)
+
 option(DINGO_DEVELOPMENT_MODE "include additional targets for development" OFF)
 
 add_library(dingo INTERFACE)
 add_library(dingo::dingo ALIAS dingo)
-target_include_directories(dingo INTERFACE include)
+target_include_directories(dingo INTERFACE
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/dingo
-    DESTINATION include
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+)
+
+install(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}Config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+)
+
+install(
+    DIRECTORY "${PROJECT_SOURCE_DIR}/include/dingo"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING PATTERN "*.h"
 )
 


### PR DESCRIPTION
Previously, when a library depending on `dingo` was installed using `cmake --install`, the process would fail with target dependency errors due to missing export target configuration (`CMake Error: install(EXPORT "<LIBRARY>Targets" ...) includes target "<LIBRARY>" which requires target "dingo" that is not in any export set.`).

This PR fixes this issue by setting up the correct export targets, beside this it sets up the correct headers based on interface type.

It might be worth adding a `DINGO_INSTALL` CMake option to control the install behavior, but that would be best in another PR.