### PR TITLE
Add Windows Server 2025 to the build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [Debug, Release]
-        os: [windows-2019, windows-2022]
+        os: [windows-2019, windows-2022, windows-2025]
         std: [17, 20, 23]
     runs-on: ${{ matrix.os }}
     steps:
@@ -124,7 +124,7 @@ jobs:
         run: |
             build/${{ matrix.config }}/dingo_test
       - name: Benchmark
-        if: ${{ matrix.config == 'Release' && matrix.os == 'windows-2019' }}
+        if: ${{ matrix.config == 'Release' }}
         run: |
             build/${{ matrix.config }}/dingo_benchmark
       - name: FetchContent


### PR DESCRIPTION
GitHub added Windows Server 2025, this PR adds it to the workflow file and lets the benchmark run on all Windows Server versions.

Just as a note: Windows Server 2019 will be deprecated somewhere in the future.