### PR TITLE
Fix VS 2026 ASan optional annotation mismatch

### DIFF
--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -36,7 +36,7 @@ function(target_sanitize NS TARGET)
             set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "ProgramDatabase")
             foreach(arg ${${NS}_SANITIZER_OPTIONS})
 		# TODO: sanitizer needs to be enabled for all code that gets linked into the binary
-		target_compile_options(${TARGET} PRIVATE /fsanitize=${arg} /D_DISABLE_VECTOR_ANNOTATION /D_DISABLE_STRING_ANNOTATION)
+		target_compile_options(${TARGET} PRIVATE /fsanitize=${arg} /D_DISABLE_VECTOR_ANNOTATION /D_DISABLE_STRING_ANNOTATION /D_DISABLE_OPTIONAL_ANNOTATION)
             endforeach()
         else()
             message(FATAL_ERROR "sanitizers are not supported for ${CMAKE_CXX_COMPILER_ID}")


### PR DESCRIPTION
## Summary

- add `_DISABLE_OPTIONAL_ANNOTATION` to the MSVC ASan compile flags
- keep the existing vector/string STL annotation workaround aligned with VS 2026 optional annotations

## Verification

- `cmake -S . -B /tmp/dingo-ci/build-fix-verify -DDINGO_DEVELOPMENT_MODE=ON -DDINGO_BENCHMARK_ENABLED=OFF -DDINGO_EXAMPLES_ENABLED=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23`
- `cmake --build /tmp/dingo-ci/build-fix-verify -j 4`
- `ctest --test-dir /tmp/dingo-ci/build-fix-verify --output-on-failure -C Debug -R "^dingo_test$"`

## Notes

Full local `ctest` is blocked in this environment because `filecheck` is missing for lit tests. The failing periodic jobs are Windows VS 2026 Debug jobs, so GitHub Actions is the decisive verification.