### PR TITLE
Expose ccache restore steps in CI

### DIFF
--- a/.github/actions/linux-build/action.yaml
+++ b/.github/actions/linux-build/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: CMake build type
     required: true
   ccache_key:
-    description: Cache key for ccache-action
+    description: Failure artifact suffix matching the caller's ccache key
     required: true
   container_image:
     description: Optional local container image to run the Linux build inside
@@ -46,13 +46,6 @@ runs:
         cache-dependency-glob: |
           ${{ inputs.source_dir }}/pyproject.toml
           ${{ inputs.source_dir }}/uv.lock
-    - name: CCache
-      uses: hendrikmuhs/ccache-action@v1.2.22
-      with:
-        key: ${{ inputs.ccache_key }}
-        restore-keys: ${{ inputs.ccache_key }}
-        max-size: 1G
-        evict-old-files: job
     - name: Install Compiler
       if: ${{ inputs.container_image == '' }}
       shell: bash

--- a/.github/actions/prepare-ccache-save/action.yaml
+++ b/.github/actions/prepare-ccache-save/action.yaml
@@ -1,0 +1,73 @@
+name: Prepare CCache save
+description: Compute the per-job ccache budget and trim the restored cache before the post-action save.
+inputs:
+  total-budget-mb:
+    description: Total repository cache budget reserved for ccache archives.
+    required: false
+    default: '5000'
+  expected-entries:
+    description: Number of ccache archives the CI matrix should be able to retain.
+    required: false
+    default: '100'
+  min-size-mb:
+    description: Minimum per-archive ccache budget.
+    required: false
+    default: '10'
+runs:
+  using: composite
+  steps:
+    - name: Prepare CCache save
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        total_budget_mb='${{ inputs.total-budget-mb }}'
+        expected_entries='${{ inputs.expected-entries }}'
+        min_size_mb='${{ inputs.min-size-mb }}'
+
+        if ! command -v ccache >/dev/null 2>&1; then
+          echo "ccache is not available; skipping save preparation"
+          exit 0
+        fi
+
+        if [ "$expected_entries" -lt 1 ]; then
+          expected_entries=1
+        fi
+
+        save_budget_mb=$((total_budget_mb / expected_entries))
+        if [ "$save_budget_mb" -lt "$min_size_mb" ]; then
+          save_budget_mb="$min_size_mb"
+        fi
+
+        echo "CCache save budget: ${save_budget_mb}M (${total_budget_mb}M / ${expected_entries} expected entries)"
+        ccache --set-config=max_size="${save_budget_mb}M"
+        ccache --cleanup
+        ccache -s -v || ccache -s
+
+    - name: Prepare CCache save
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $totalBudgetMb = [int]'${{ inputs.total-budget-mb }}'
+        $expectedEntries = [int]'${{ inputs.expected-entries }}'
+        $minSizeMb = [int]'${{ inputs.min-size-mb }}'
+
+        if (-not (Get-Command ccache -ErrorAction SilentlyContinue)) {
+          Write-Host "ccache is not available; skipping save preparation"
+          exit 0
+        }
+
+        if ($expectedEntries -lt 1) {
+          $expectedEntries = 1
+        }
+
+        $saveBudgetMb = [math]::Floor($totalBudgetMb / $expectedEntries)
+        if ($saveBudgetMb -lt $minSizeMb) {
+          $saveBudgetMb = $minSizeMb
+        }
+
+        Write-Host "CCache save budget: ${saveBudgetMb}M (${totalBudgetMb}M / ${expectedEntries} expected entries)"
+        ccache --set-config=max_size="${saveBudgetMb}M"
+        ccache --cleanup
+        ccache -s -v

--- a/.github/actions/prepare-ccache-save/action.yaml
+++ b/.github/actions/prepare-ccache-save/action.yaml
@@ -4,7 +4,7 @@ inputs:
   total-budget-mb:
     description: Total repository cache budget reserved for ccache archives.
     required: false
-    default: '5000'
+    default: '10000'
   expected-entries:
     description: Number of ccache archives the CI matrix should be able to retain.
     required: false

--- a/.github/actions/windows-build/action.yaml
+++ b/.github/actions/windows-build/action.yaml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: build
   ccache_key:
-    description: Cache key for ccache-action
+    description: Failure artifact suffix matching the caller's ccache key
     required: true
   config_id:
     description: Visual Studio configuration id
@@ -36,11 +36,6 @@ runs:
         cache-dependency-glob: |
           ${{ inputs.source_dir }}/pyproject.toml
           ${{ inputs.source_dir }}/uv.lock
-    - name: CCache
-      uses: hendrikmuhs/ccache-action@v1.2.22
-      with:
-        key: ${{ inputs.ccache_key }}
-        evict-old-files: job
     - name: Configure
       shell: pwsh
       run: |

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -83,6 +83,11 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
 
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: bash
+        run: ccache --cleanup || true
+
   linux-toolchain-image:
     name: ubuntu-25.04 / ${{ matrix.compiler.TOOLCHAIN }} / std-${{ matrix.compiler.STD }} / ${{ matrix.config.label }}
     timeout-minutes: 60
@@ -160,6 +165,11 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
 
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: bash
+        run: ccache --cleanup || true
+
   linux-arm64:
     name: ubuntu-24.04-arm / ${{ matrix.compiler.CXX }} / std-${{ matrix.compiler.STD }} / ${{ matrix.config.label }}
     timeout-minutes: 45
@@ -217,6 +227,11 @@ jobs:
           sanitizer: ${{ matrix.compiler.SANITIZER }}
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
+
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: bash
+        run: ccache --cleanup || true
 
   windows-x64:
     name: ${{ matrix.vs.label }} / x64 / std-${{ matrix.std }} / ${{ matrix.config.label }}
@@ -285,6 +300,13 @@ jobs:
           generator: ${{ matrix.vs.generator }}
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.std }}
+
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          ccache --cleanup
+          exit 0
 
   windows-arm64-vs2026:
     name: vs2026 / arm64 / std-${{ matrix.std }} / ${{ matrix.config.label }}
@@ -362,6 +384,13 @@ jobs:
         run: |
           cmake -S "${{ env.SOURCE_DIR }}/test/fetchcontent" -B fetchcontent-build -G "Visual Studio 18 2026" -A ARM64 -DCMAKE_BUILD_TYPE=${{ matrix.config.id }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DDINGO_EXAMPLES_ENABLED=OFF
           cmake --build fetchcontent-build --config ${{ matrix.config.id }} -j $env:BUILD_JOBS -- /nodeReuse:false
+
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          ccache --cleanup
+          exit 0
 
       - name: Upload Failure Artifacts
         if: ${{ failure() }}

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -10,7 +10,7 @@ on:
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
   DINGO_CCACHE_EXPECTED_ENTRIES: ${{ vars.DINGO_CCACHE_EXPECTED_ENTRIES || '100' }}
-  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '5000' }}
+  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '10000' }}
 
 jobs:
   linux:
@@ -70,7 +70,7 @@ jobs:
           key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
 
@@ -153,7 +153,7 @@ jobs:
           key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
 
@@ -219,7 +219,7 @@ jobs:
           key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
 
@@ -296,7 +296,7 @@ jobs:
           key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
             ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
 
@@ -373,7 +373,7 @@ jobs:
           key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
             vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -65,9 +65,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+          key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+            ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           max-size: 250M
           verbose: 1
           evict-old-files: job
@@ -141,9 +141,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+          key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+            ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           max-size: 250M
           verbose: 1
           evict-old-files: job
@@ -200,9 +200,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+          key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
+            ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           max-size: 250M
           verbose: 1
           evict-old-files: job
@@ -270,9 +270,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}
+          key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
-            ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}
+            ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
           max-size: 250M
           verbose: 1
           evict-old-files: job
@@ -340,9 +340,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: vs2026-arm64-${{ matrix.config.id }}
+          key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
-            vs2026-arm64-${{ matrix.config.id }}
+            vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
           max-size: 250M
           verbose: 1
           evict-old-files: job

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+            ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           max-size: 1G
           verbose: 1
           evict-old-files: job
@@ -143,7 +143,7 @@ jobs:
         with:
           key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+            ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           max-size: 1G
           verbose: 1
           evict-old-files: job
@@ -202,7 +202,7 @@ jobs:
         with:
           key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
-            ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+            ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           max-size: 1G
           verbose: 1
           evict-old-files: job
@@ -272,7 +272,7 @@ jobs:
         with:
           key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
-            ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-
+            ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}
           max-size: 1G
           verbose: 1
           evict-old-files: job
@@ -342,7 +342,7 @@ jobs:
         with:
           key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
-            vs2026-arm64-${{ matrix.config.id }}-
+            vs2026-arm64-${{ matrix.config.id }}
           max-size: 1G
           verbose: 1
           evict-old-files: job

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -9,6 +9,8 @@ on:
 
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
+  DINGO_CCACHE_EXPECTED_ENTRIES: ${{ vars.DINGO_CCACHE_EXPECTED_ENTRIES || '100' }}
+  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '5000' }}
 
 jobs:
   linux:
@@ -83,10 +85,12 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
 
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: bash
-        run: ccache --cleanup || true
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
 
   linux-toolchain-image:
     name: ubuntu-25.04 / ${{ matrix.compiler.TOOLCHAIN }} / std-${{ matrix.compiler.STD }} / ${{ matrix.config.label }}
@@ -165,10 +169,12 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
 
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: bash
-        run: ccache --cleanup || true
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
 
   linux-arm64:
     name: ubuntu-24.04-arm / ${{ matrix.compiler.CXX }} / std-${{ matrix.compiler.STD }} / ${{ matrix.config.label }}
@@ -228,10 +234,12 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.compiler.STD }}
 
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: bash
-        run: ccache --cleanup || true
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
 
   windows-x64:
     name: ${{ matrix.vs.label }} / x64 / std-${{ matrix.std }} / ${{ matrix.config.label }}
@@ -301,12 +309,12 @@ jobs:
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.std }}
 
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          ccache --cleanup
-          exit 0
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
 
   windows-arm64-vs2026:
     name: vs2026 / arm64 / std-${{ matrix.std }} / ${{ matrix.config.label }}
@@ -385,12 +393,12 @@ jobs:
           cmake -S "${{ env.SOURCE_DIR }}/test/fetchcontent" -B fetchcontent-build -G "Visual Studio 18 2026" -A ARM64 -DCMAKE_BUILD_TYPE=${{ matrix.config.id }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DDINGO_EXAMPLES_ENABLED=OFF
           cmake --build fetchcontent-build --config ${{ matrix.config.id }} -j $env:BUILD_JOBS -- /nodeReuse:false
 
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          ccache --cleanup
-          exit 0
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
 
       - name: Upload Failure Artifacts
         if: ${{ failure() }}

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -62,6 +62,16 @@ jobs:
           tar -xzf release-artifacts/release-source.tar.gz -C release-src
           echo "SOURCE_DIR=release-src" >> "$GITHUB_ENV"
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          restore-keys: |
+            ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+          max-size: 1G
+          verbose: 1
+          evict-old-files: job
+
       - name: Run Linux build
         uses: ./.github/actions/linux-build
         with:
@@ -128,6 +138,16 @@ jobs:
           tar -xzf release-artifacts/release-source.tar.gz -C release-src
           echo "SOURCE_DIR=release-src" >> "$GITHUB_ENV"
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          restore-keys: |
+            ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+          max-size: 1G
+          verbose: 1
+          evict-old-files: job
+
       - name: Run Linux image-backed build
         uses: ./.github/actions/linux-build
         with:
@@ -176,6 +196,16 @@ jobs:
           mkdir -p release-src
           tar -xzf release-artifacts/release-source.tar.gz -C release-src
           echo "SOURCE_DIR=release-src" >> "$GITHUB_ENV"
+
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          restore-keys: |
+            ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-
+          max-size: 1G
+          verbose: 1
+          evict-old-files: job
 
       - name: Run Linux arm64 build
         uses: ./.github/actions/linux-build

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -65,10 +65,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           restore-keys: |
             ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
 
@@ -116,7 +116,7 @@ jobs:
           load: true
           tags: dingo-toolchains:ubuntu-25.04-${{ matrix.compiler.TOOLCHAIN }}
           cache-from: type=gha,scope=toolchain-${{ matrix.compiler.TOOLCHAIN }}
-          cache-to: type=gha,mode=max,scope=toolchain-${{ matrix.compiler.TOOLCHAIN }}
+          cache-to: type=gha,mode=min,scope=toolchain-${{ matrix.compiler.TOOLCHAIN }}
 
       - name: Initialize source dir
         shell: bash
@@ -141,10 +141,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           restore-keys: |
             ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
 
@@ -200,10 +200,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
+          key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
           restore-keys: |
             ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
 
@@ -270,10 +270,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
+          key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}
           restore-keys: |
             ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
 
@@ -340,10 +340,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
+          key: vs2026-arm64-${{ matrix.config.id }}
           restore-keys: |
             vs2026-arm64-${{ matrix.config.id }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -68,7 +68,7 @@ jobs:
           key: ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-24.04-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
 
@@ -149,7 +149,7 @@ jobs:
           key: ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-25.04-image-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
 
@@ -213,7 +213,7 @@ jobs:
           key: ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
           restore-keys: |
             ubuntu-24.04-arm-${{ matrix.config.id }}-${{ matrix.compiler.CXX }}-${{ matrix.compiler.STD }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
 
@@ -288,7 +288,7 @@ jobs:
           key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
             ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
 
@@ -365,7 +365,7 @@ jobs:
           key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
           restore-keys: |
             vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -267,6 +267,16 @@ jobs:
           tar -xzf release-artifacts/release-source.tar.gz -C release-src
           echo "SOURCE_DIR=release-src" >> "$GITHUB_ENV"
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
+          restore-keys: |
+            ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-
+          max-size: 1G
+          verbose: 1
+          evict-old-files: job
+
       - name: Run Windows build
         uses: ./.github/actions/windows-build
         with:
@@ -331,6 +341,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
+          restore-keys: |
+            vs2026-arm64-${{ matrix.config.id }}-
+          max-size: 1G
+          verbose: 1
           evict-old-files: job
 
       - name: Configure

--- a/.github/workflows/toolchain-images.yaml
+++ b/.github/workflows/toolchain-images.yaml
@@ -54,7 +54,7 @@ jobs:
           load: true
           tags: dingo-toolchains:ubuntu-25.04-${{ matrix.compiler.toolchain }}
           cache-from: type=gha,scope=toolchain-smoke-${{ matrix.compiler.toolchain }}
-          cache-to: type=gha,mode=max,scope=toolchain-smoke-${{ matrix.compiler.toolchain }}
+          cache-to: type=gha,mode=min,scope=toolchain-smoke-${{ matrix.compiler.toolchain }}
 
       - name: Smoke test container command
         shell: bash
@@ -109,7 +109,7 @@ jobs:
           load: true
           tags: dingo-toolchains:ubuntu-25.04-msvc-wine
           cache-from: type=gha,scope=toolchain-smoke-msvc-wine
-          cache-to: type=gha,mode=max,scope=toolchain-smoke-msvc-wine
+          cache-to: type=gha,mode=min,scope=toolchain-smoke-msvc-wine
 
       - name: Verify msvc-wine image baseline tools
         shell: bash

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -71,10 +71,10 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
+          key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}
           restore-keys: |
             ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}
-          max-size: 1G
+          max-size: 250M
           verbose: 1
           evict-old-files: job
       - name: Configure

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -74,7 +74,7 @@ jobs:
           key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
           restore-keys: |
             ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
-          max-size: 250M
+          max-size: 50M
           verbose: 1
           evict-old-files: job
       - name: Configure

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -71,9 +71,9 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
-          key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}
+          key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
           restore-keys: |
-            ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}
+            ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
           max-size: 250M
           verbose: 1
           evict-old-files: job

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -30,6 +30,8 @@ on:
 
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
+  DINGO_CCACHE_EXPECTED_ENTRIES: ${{ vars.DINGO_CCACHE_EXPECTED_ENTRIES || '100' }}
+  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '5000' }}
 
 jobs:
   cross:
@@ -101,12 +103,12 @@ jobs:
         run: |
           cmake -S "${{ env.SOURCE_DIR }}/test/fetchcontent" -B fetchcontent-build -G "${{ inputs.cross_generator }}" -A ARM64 -DCMAKE_BUILD_TYPE=${{ inputs.config_id }} -DCMAKE_CXX_STANDARD=${{ inputs.std }}
           cmake --build fetchcontent-build --config ${{ inputs.config_id }} -j $env:BUILD_JOBS -- /nodeReuse:false
-      - name: Trim CCache
+      - name: Prepare CCache save
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          ccache --cleanup
-          exit 0
+        uses: ./.github/actions/prepare-ccache-save
+        with:
+          total-budget-mb: ${{ env.DINGO_CCACHE_TOTAL_MB }}
+          expected-entries: ${{ env.DINGO_CCACHE_EXPECTED_ENTRIES }}
       - name: Upload Failure Artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -101,6 +101,12 @@ jobs:
         run: |
           cmake -S "${{ env.SOURCE_DIR }}/test/fetchcontent" -B fetchcontent-build -G "${{ inputs.cross_generator }}" -A ARM64 -DCMAKE_BUILD_TYPE=${{ inputs.config_id }} -DCMAKE_CXX_STANDARD=${{ inputs.std }}
           cmake --build fetchcontent-build --config ${{ inputs.config_id }} -j $env:BUILD_JOBS -- /nodeReuse:false
+      - name: Trim CCache
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          ccache --cleanup
+          exit 0
       - name: Upload Failure Artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -31,7 +31,7 @@ on:
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
   DINGO_CCACHE_EXPECTED_ENTRIES: ${{ vars.DINGO_CCACHE_EXPECTED_ENTRIES || '100' }}
-  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '5000' }}
+  DINGO_CCACHE_TOTAL_MB: ${{ vars.DINGO_CCACHE_TOTAL_MB || '10000' }}
 
 jobs:
   cross:
@@ -76,7 +76,7 @@ jobs:
           key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
           restore-keys: |
             ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
-          max-size: 50M
+          max-size: 100M
           verbose: 1
           evict-old-files: job
       - name: Configure

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
           restore-keys: |
-            ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-
+            ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}
           max-size: 1G
           verbose: 1
           evict-old-files: job

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -72,6 +72,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
+          restore-keys: |
+            ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-
+          max-size: 1G
+          verbose: 1
           evict-old-files: job
       - name: Configure
         shell: pwsh


### PR DESCRIPTION
## Summary

- move Linux and Windows x64 ccache setup out of composite actions so restore/save diagnostics are visible in job steps
- add compiler/config-level restore prefixes for Linux, Linux image, Linux arm64, Windows x64, and Windows arm64 build legs
- enable verbose ccache-action logging for restore decisions

## Testing

- python3 YAML parse check for changed workflow/action files
- git diff --cached --check before each commit