### PR TITLE
Reduce CI cache pressure

### DIFF
--- a/.github/actions/linux-build/action.yaml
+++ b/.github/actions/linux-build/action.yaml
@@ -51,7 +51,7 @@ runs:
       with:
         key: ${{ inputs.ccache_key }}
         restore-keys: ${{ inputs.ccache_key }}
-        max-size: 1G
+        max-size: ${{ env.CCACHE_MAX_SIZE }}
         evict-old-files: job
     - name: Install Compiler
       if: ${{ inputs.container_image == '' }}

--- a/.github/actions/linux-build/action.yaml
+++ b/.github/actions/linux-build/action.yaml
@@ -112,6 +112,11 @@ runs:
             command -v uv
             uv --version
 
+            echo "::group::Initial ccache stats"
+            ccache --show-stats --verbose
+            ccache --zero-stats
+            echo "::endgroup::"
+
             cmake -S "/workspace/${{ inputs.source_dir }}" \
               -B "/workspace/${{ inputs.build_dir }}" \
               -DDINGO_DEVELOPMENT_MODE=ON \
@@ -124,15 +129,24 @@ runs:
 
             cmake --build "/workspace/${{ inputs.build_dir }}" -j "$BUILD_JOBS"
 
+            echo "::group::Main build ccache stats"
+            ccache --show-stats --verbose
+            echo "::endgroup::"
+
             cd "/workspace/${{ inputs.build_dir }}"
             ASAN_OPTIONS=use_sigaltstack=false ctest --verbose --output-on-failure
 
             cmake -S "/workspace/${{ inputs.source_dir }}/test/fetchcontent" \
               -B "/workspace/${{ inputs.fetchcontent_dir }}" \
+              -DDINGO_CCACHE=ON \
               -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
               -DCMAKE_CXX_STANDARD=${{ inputs.std }}
 
             cmake --build "/workspace/${{ inputs.fetchcontent_dir }}" -j "$BUILD_JOBS"
+
+            echo "::group::Final ccache stats"
+            ccache --show-stats --verbose
+            echo "::endgroup::"
           '
     - name: Upload Failure Artifacts
       if: ${{ failure() }}

--- a/.github/actions/windows-build/action.yaml
+++ b/.github/actions/windows-build/action.yaml
@@ -40,6 +40,7 @@ runs:
       uses: hendrikmuhs/ccache-action@v1.2.22
       with:
         key: ${{ inputs.ccache_key }}
+        max-size: ${{ env.CCACHE_MAX_SIZE }}
         evict-old-files: job
     - name: Configure
       shell: pwsh

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -80,7 +80,9 @@ jobs:
           - id: Release
             label: release
         compiler:
+          - { TOOLCHAIN: gcc-15, CC: gcc-15, CXX: g++-15, STD: 23, SANITIZER: ON }
           - { TOOLCHAIN: gcc-15, CC: gcc-15, CXX: g++-15, STD: 26, SANITIZER: ON }
+          - { TOOLCHAIN: clang-20, CC: clang-20, CXX: clang++-20, STD: 23, SANITIZER: ON }
           - { TOOLCHAIN: clang-20, CC: clang-20, CXX: clang++-20, STD: 26, SANITIZER: ON }
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
+  CCACHE_MAX_SIZE: ${{ vars.DINGO_CCACHE_MAX_SIZE || '700M' }}
 
 jobs:
   linux:
@@ -18,24 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - id: Debug
-            label: debug
+          # Debug builds are temporarily disabled to keep ccache pressure inside
+          # the repository cache budget.
+          # - id: Debug
+          #   label: debug
           - id: Release
             label: release
         compiler:
           - { CC: gcc-13, CXX: g++-13, STD: 17, SANITIZER: ON }
-          - { CC: gcc-13, CXX: g++-13, STD: 20, SANITIZER: ON }
-          - { CC: gcc-13, CXX: g++-13, STD: 23, SANITIZER: ON }
-          - { CC: gcc-14, CXX: g++-14, STD: 17, SANITIZER: ON }
-          - { CC: gcc-14, CXX: g++-14, STD: 20, SANITIZER: ON }
           - { CC: gcc-14, CXX: g++-14, STD: 23, SANITIZER: ON }
-          - { CC: gcc-14, CXX: g++-14, STD: 26, SANITIZER: ON }
-          - { CC: clang-18, CXX: clang++-18, STD: 17, SANITIZER: ON }
           - { CC: clang-18, CXX: clang++-18, STD: 20, SANITIZER: ON }
-          - { CC: clang-18, CXX: clang++-18, STD: 23, SANITIZER: ON }
-          - { CC: clang-19, CXX: clang++-19, STD: 17, SANITIZER: ON }
-          - { CC: clang-19, CXX: clang++-19, STD: 20, SANITIZER: ON }
-          - { CC: clang-19, CXX: clang++-19, STD: 23, SANITIZER: ON }
           - { CC: clang-19, CXX: clang++-19, STD: 26, SANITIZER: ON }
     runs-on: ubuntu-24.04
     steps:
@@ -80,14 +73,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - id: Debug
-            label: debug
+          # Debug builds are temporarily disabled to keep ccache pressure inside
+          # the repository cache budget.
+          # - id: Debug
+          #   label: debug
           - id: Release
             label: release
         compiler:
-          - { TOOLCHAIN: gcc-15, CC: gcc-15, CXX: g++-15, STD: 23, SANITIZER: ON }
           - { TOOLCHAIN: gcc-15, CC: gcc-15, CXX: g++-15, STD: 26, SANITIZER: ON }
-          - { TOOLCHAIN: clang-20, CC: clang-20, CXX: clang++-20, STD: 23, SANITIZER: ON }
           - { TOOLCHAIN: clang-20, CC: clang-20, CXX: clang++-20, STD: 26, SANITIZER: ON }
     runs-on: ubuntu-24.04
     steps:
@@ -151,7 +144,7 @@ jobs:
             label: release
         compiler:
           - { CC: gcc-14, CXX: g++-14, STD: 23, SANITIZER: ON }
-          - { CC: clang-18, CXX: clang++-18, STD: 23, SANITIZER: ON }
+          - { CC: clang-18, CXX: clang++-18, STD: 20, SANITIZER: ON }
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout workflow repo
@@ -189,25 +182,39 @@ jobs:
           std: ${{ matrix.compiler.STD }}
 
   windows-x64:
-    name: ${{ matrix.vs.label }} / x64 / std-${{ matrix.std }} / ${{ matrix.config.label }}
+    name: ${{ matrix.vs_label }} / x64 / std-${{ matrix.std }} / ${{ matrix.config_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - id: Debug
-            label: debug
-          - id: Release
-            label: release
-        std: [17, 20, 23]
-        vs:
-          - label: vs2022
+        include:
+          # Debug builds are temporarily disabled to keep ccache pressure inside
+          # the repository cache budget.
+          # - vs_label: vs2022
+          #   config_id: Debug
+          #   config_label: debug
+          #   std: 17
+          #   runner: windows-2022
+          #   generator: Visual Studio 17 2022
+          - vs_label: vs2022
+            config_id: Release
+            config_label: release
+            std: 17
             runner: windows-2022
             generator: Visual Studio 17 2022
-          - label: vs2026
+          - vs_label: vs2022
+            config_id: Release
+            config_label: release
+            std: 20
+            runner: windows-2022
+            generator: Visual Studio 17 2022
+          - vs_label: vs2026
+            config_id: Release
+            config_label: release
+            std: 23
             runner: windows-2025-vs2026
             generator: Visual Studio 18 2026
-    runs-on: ${{ matrix.vs.runner }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Setup MSVC Developer Command Prompt
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
@@ -240,9 +247,9 @@ jobs:
       - name: Run Windows build
         uses: ./.github/actions/windows-build
         with:
-          ccache_key: ${{ matrix.vs.label }}-x64-${{ matrix.config.id }}-${{ matrix.std }}
-          config_id: ${{ matrix.config.id }}
-          generator: ${{ matrix.vs.generator }}
+          ccache_key: ${{ matrix.vs_label }}-x64-${{ matrix.config_id }}-${{ matrix.std }}
+          config_id: ${{ matrix.config_id }}
+          generator: ${{ matrix.generator }}
           source_dir: ${{ env.SOURCE_DIR }}
           std: ${{ matrix.std }}
 
@@ -253,11 +260,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - id: Debug
-            label: debug
+          # Debug builds are temporarily disabled to keep ccache pressure inside
+          # the repository cache budget.
+          # - id: Debug
+          #   label: debug
           - id: Release
             label: release
-        std: [17, 20, 23]
+        std: [23]
     runs-on: windows-2025-vs2026
     steps:
       - name: Setup MSVC Developer Command Prompt
@@ -301,6 +310,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: vs2026-arm64-${{ matrix.config.id }}-${{ matrix.std }}
+          max-size: ${{ env.CCACHE_MAX_SIZE }}
           evict-old-files: job
 
       - name: Configure
@@ -338,11 +348,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - id: Debug
-            label: debug
+          # Debug builds are temporarily disabled to keep ccache pressure inside
+          # the repository cache budget.
+          # - id: Debug
+          #   label: debug
           - id: Release
             label: release
-        std: [17, 20, 23]
+        std: [17]
     uses: ./.github/workflows/windows-arm64-leg.yaml
     with:
       source_artifact_name: ${{ inputs.source_artifact_name }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,4 +1,4 @@
-name: toolchain-images
+name: images
 permissions:
   contents: read
 env:
@@ -13,7 +13,7 @@ on:
       - docker/ubuntu25-toolchains/**
       - .github/actions/linux-build/action.yaml
       - .github/workflows/build-reusable.yaml
-      - .github/workflows/toolchain-images.yaml
+      - .github/workflows/images.yaml
   push:
     branches:
       - master
@@ -21,7 +21,7 @@ on:
       - docker/ubuntu25-toolchains/**
       - .github/actions/linux-build/action.yaml
       - .github/workflows/build-reusable.yaml
-      - .github/workflows/toolchain-images.yaml
+      - .github/workflows/images.yaml
 
 jobs:
   linux-toolchain-smoke:

--- a/.github/workflows/toolchain-images.yaml
+++ b/.github/workflows/toolchain-images.yaml
@@ -1,6 +1,8 @@
 name: toolchain-images
 permissions:
   contents: read
+env:
+  CCACHE_MAX_SIZE: ${{ vars.DINGO_CCACHE_MAX_SIZE || '700M' }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -56,26 +58,46 @@ jobs:
           cache-from: type=gha,scope=toolchain-smoke-${{ matrix.compiler.toolchain }}
           cache-to: type=gha,mode=max,scope=toolchain-smoke-${{ matrix.compiler.toolchain }}
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: toolchain-smoke-${{ matrix.compiler.toolchain }}-std-23
+          max-size: ${{ env.CCACHE_MAX_SIZE }}
+          evict-old-files: job
+
       - name: Smoke test container command
         shell: bash
         run: |
           set -euo pipefail
 
+          mkdir -p "$GITHUB_WORKSPACE/.ccache"
+          echo "Using ccache directory: $GITHUB_WORKSPACE/.ccache"
+
           docker run --rm \
             --user "$(id -u):$(id -g)" \
+            -e CCACHE_DIR=/ccache \
             -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "$GITHUB_WORKSPACE/.ccache:/ccache" \
             -w /workspace \
             dingo-toolchains:ubuntu-25.04-${{ matrix.compiler.toolchain }} \
             bash -lc 'set -euxo pipefail
               command -v uv
               uv --version
+              echo "::group::Initial ccache stats"
+              ccache --show-stats --verbose
+              ccache --zero-stats
+              echo "::endgroup::"
               export NINJA_STATUS="[%f/%t %es] "
               cmake -S /workspace -B /workspace/${{ matrix.compiler.build_dir }} -G Ninja \
               -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
               -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
               -DDINGO_DEVELOPMENT_MODE=ON \
-              -DDINGO_BENCHMARK_ENABLED=OFF && \
+              -DDINGO_BENCHMARK_ENABLED=OFF \
+              -DDINGO_CCACHE=ON && \
               cmake --build /workspace/${{ matrix.compiler.build_dir }} --target dingo_unit_test --verbose -j"$(nproc)" && \
+              echo "::group::Smoke build ccache stats" && \
+              ccache --show-stats --verbose && \
+              echo "::endgroup::" && \
               ctest --test-dir /workspace/${{ matrix.compiler.build_dir }} --output-on-failure -R "^dingo_unit_test$"'
 
       - name: Upload Failure Artifacts

--- a/.github/workflows/windows-arm64-leg.yaml
+++ b/.github/workflows/windows-arm64-leg.yaml
@@ -30,6 +30,7 @@ on:
 
 env:
   BUILD_JOBS: ${{ vars.DINGO_BUILD_JOBS || '4' }}
+  CCACHE_MAX_SIZE: ${{ vars.DINGO_CCACHE_MAX_SIZE || '700M' }}
 
 jobs:
   cross:
@@ -72,6 +73,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ inputs.vs_label }}-arm64-${{ inputs.config_id }}-${{ inputs.std }}
+          max-size: ${{ env.CCACHE_MAX_SIZE }}
           evict-old-files: job
       - name: Configure
         shell: pwsh

--- a/test/matrix/generate.py
+++ b/test/matrix/generate.py
@@ -57,7 +57,6 @@ class CandidateRow:
 class MatrixRow(CandidateRow):
     plan: RegistrationPlan
     name: str
-    source_name: str
     lines: CaseLines = CaseLines()
 
 
@@ -261,7 +260,6 @@ def generate_rows() -> tuple[MatrixRow, ...]:
                                         container=container,
                                         plan=plan,
                                         name=case_name(candidate),
-                                        source_name=source_name(candidate),
                                         lines=lines,
                                     )
                                 )
@@ -364,10 +362,6 @@ def case_name(row: CandidateRow) -> str:
     )
 
 
-def source_name(row: CandidateRow) -> str:
-    return "_".join((row.feature.name, row.mode.name, row.container.name))
-
-
 def make_case(row: MatrixRow) -> GeneratedCase:
     static_bindings = None
     setup_lines = ()
@@ -458,13 +452,6 @@ def executable_name(feature_name: str) -> str:
     return f"dingo_matrix_test_{feature_name}"
 
 
-def source_groups(rows: tuple[MatrixRow, ...]) -> dict[str, list[MatrixRow]]:
-    grouped: dict[str, list[MatrixRow]] = defaultdict(list)
-    for row in rows:
-        grouped[row.source_name].append(row)
-    return grouped
-
-
 def executable_groups(rows: tuple[MatrixRow, ...]) -> dict[str, list[MatrixRow]]:
     grouped: dict[str, list[MatrixRow]] = defaultdict(list)
     for row in rows:
@@ -478,30 +465,32 @@ def generate_sources(
     source_template: Template,
     runner_template: Template,
 ) -> tuple[GeneratedExecutable, ...]:
-    sources_by_group: dict[str, Path] = {}
-    rows_by_source = source_groups(rows)
-    for group_name, group_rows in rows_by_source.items():
-        source = out_dir / f"{group_name}.cpp"
-        sources_by_group[group_name] = render_source(source, group_rows, source_template)
-
     executables: list[GeneratedExecutable] = []
     for feature_name, feature_rows in executable_groups(rows).items():
+        source = render_source(
+            out_dir / f"{feature_name}.cpp",
+            feature_rows,
+            source_template,
+        )
         runner = render_runner(
             out_dir / f"matrix_runner_{feature_name}.cpp",
             tuple(feature_rows),
             runner_template,
         )
-        feature_sources = {
-            sources_by_group[row.source_name] for row in feature_rows
-        }
         executables.append(
             GeneratedExecutable(
                 name=executable_name(feature_name),
-                sources=tuple(sorted((*feature_sources, runner))),
+                sources=(source, runner),
             )
         )
 
     return tuple(sorted(executables, key=lambda executable: executable.name))
+
+
+def remove_stale_sources(out_dir: Path, live_sources: set[Path]) -> None:
+    for source in out_dir.glob("*.cpp"):
+        if source not in live_sources:
+            source.unlink()
 
 
 def generate(out_dir: Path, cmake_file: Path) -> None:
@@ -520,6 +509,10 @@ def generate(out_dir: Path, cmake_file: Path) -> None:
         out_dir,
         env.get_template("source.cpp.j2"),
         env.get_template("runner.cpp.j2"),
+    )
+    remove_stale_sources(
+        out_dir,
+        {source for executable in executables for source in executable.sources},
     )
     cmake_file.parent.mkdir(parents=True, exist_ok=True)
     write_text_if_changed(


### PR DESCRIPTION
## Summary
- standardize all CI ccache-action users on shared CCACHE_MAX_SIZE, defaulting to 700M
- keep Debug matrix entries commented out while leaving Release active
- trim compiler and standard coverage to representative lanes instead of full cartesian expansion
- keep GCC 15 and Clang 20 on both C++23 and C++26 in the toolchain-image lanes
- rename the standalone toolchain image workflow to images, matching the lint/build workflow naming style
- print ccache stats from inside Docker-backed reusable build jobs before the build, after the main build, and after FetchContent
- restore, mount, enable, and report ccache stats in standalone image smoke containers
- generate matrix tests as one implementation source plus one runner per feature, with stale generated source cleanup

## Active matrix shape
- linux: 4 jobs
- linux-toolchain-image: 4 jobs
- linux-arm64: 2 jobs
- windows-x64: 3 jobs
- windows-arm64-vs2026: 1 job
- windows-arm64-vs2022: 1 job

Total active build combinations: 15.

## Verification
- git diff --check
- python -m py_compile test/matrix/generate.py
- YAML parse for edited workflows and actions
- parsed matrix count is 15 active build combinations
- fresh Release/std17 configure generated 62 matrix .cpp files
- cmake --build build/tmp/verify-matrix-less-granular --target dingo_matrix_test -j 4
- ctest --test-dir build/tmp/verify-matrix-less-granular -L runtime --output-on-failure, 31/31 passed

Not run: actionlint, not installed locally.
Not run: GitHub-hosted Docker/image smoke jobs locally.