### PR TITLE
Centralize generic type-list helpers

### DIFF
--- a/include/dingo/registration/type_registration.h
+++ b/include/dingo/registration/type_registration.h
@@ -101,41 +101,6 @@ template <typename... Args> struct dependencies<type_list<Args...>> {
 };
 
 namespace detail {
-template <typename Accumulated, typename Remaining> struct registration_type_list_unique;
-
-template <typename... Accumulated>
-struct registration_type_list_unique<type_list<Accumulated...>, type_list<>> {
-    using type = type_list<Accumulated...>;
-};
-
-template <typename T, typename List> struct registration_type_list_contains;
-
-template <typename T>
-struct registration_type_list_contains<T, type_list<>> : std::false_type {};
-
-template <typename T, typename Head, typename... Tail>
-struct registration_type_list_contains<T, type_list<Head, Tail...>>
-    : std::bool_constant<
-          std::is_same_v<T, Head> ||
-          registration_type_list_contains<T, type_list<Tail...>>::value> {};
-
-template <typename... Accumulated, typename Head, typename... Tail>
-struct registration_type_list_unique<type_list<Accumulated...>,
-                                     type_list<Head, Tail...>> {
-  private:
-    using next_accumulated = std::conditional_t<
-        registration_type_list_contains<Head, type_list<Accumulated...>>::value,
-        type_list<Accumulated...>, type_list<Accumulated..., Head>>;
-
-  public:
-    using type = typename registration_type_list_unique<
-        next_accumulated, type_list<Tail...>>::type;
-};
-
-template <typename List>
-using registration_type_list_unique_t =
-    typename registration_type_list_unique<type_list<>, List>::type;
-
 template <typename Type, typename = void> struct deduced_interface_types {
     using type = type_list<std::remove_cv_t<std::remove_reference_t<Type>>>;
 };
@@ -174,7 +139,7 @@ struct deduced_interface_types<
     };
 
   public:
-    using type = registration_type_list_unique_t<type_list_cat_t<
+    using type = type_list_unique_t<type_list_cat_t<
         type_list<value_type>,
         typename alternatives_interface_types<
             alternative_type_alternatives_t<value_type>>::type>>;

--- a/include/dingo/static/graph.h
+++ b/include/dingo/static/graph.h
@@ -55,19 +55,6 @@ template <typename DependencyBindings>
 using filter_resolved_dependency_bindings_t =
     typename filter_resolved_dependency_bindings<DependencyBindings>::type;
 
-template <typename T, typename List> struct type_list_contains;
-
-template <typename T>
-struct type_list_contains<T, type_list<>> : std::false_type {};
-
-template <typename T, typename Head, typename... Tail>
-struct type_list_contains<T, type_list<Head, Tail...>>
-    : std::bool_constant<std::is_same_v<T, Head> ||
-                         type_list_contains<T, type_list<Tail...>>::value> {};
-
-template <typename T, typename List>
-inline constexpr bool type_list_contains_v = type_list_contains<T, List>::value;
-
 template <typename InterfaceBinding, typename StaticRegistry,
           bool RuntimeDependencies = false>
 struct static_graph_node {

--- a/include/dingo/static/registry.h
+++ b/include/dingo/static/registry.h
@@ -34,46 +34,6 @@ using binding_dependencies_t = typename BindingModel::dependencies_type::type;
 
 template <typename...> inline constexpr bool dependent_false_v = false;
 
-template <typename T, typename List> struct binding_type_list_contains;
-
-template <typename T>
-struct binding_type_list_contains<T, type_list<>> : std::false_type {};
-
-template <typename T, typename Head, typename... Tail>
-struct binding_type_list_contains<T, type_list<Head, Tail...>>
-    : std::bool_constant<
-          std::is_same_v<T, Head> ||
-          binding_type_list_contains<T, type_list<Tail...>>::value> {};
-
-template <typename T, typename List>
-inline constexpr bool binding_type_list_contains_v =
-    binding_type_list_contains<T, List>::value;
-
-template <typename Accumulated, typename Remaining>
-struct type_list_unique_impl;
-
-template <typename... Accumulated>
-struct type_list_unique_impl<type_list<Accumulated...>, type_list<>> {
-    using type = type_list<Accumulated...>;
-};
-
-template <typename... Accumulated, typename Head, typename... Tail>
-struct type_list_unique_impl<type_list<Accumulated...>,
-                             type_list<Head, Tail...>> {
-  private:
-    using next_accumulated = std::conditional_t<
-        binding_type_list_contains_v<Head, type_list<Accumulated...>>,
-        type_list<Accumulated...>, type_list<Accumulated..., Head>>;
-
-  public:
-    using type = typename type_list_unique_impl<next_accumulated,
-                                                type_list<Tail...>>::type;
-};
-
-template <typename List>
-using type_list_unique_t =
-    typename type_list_unique_impl<type_list<>, List>::type;
-
 template <typename Head, typename List> struct type_list_prepend;
 
 template <typename Head, typename... Tail>

--- a/include/dingo/type/type_list.h
+++ b/include/dingo/type/type_list.h
@@ -61,6 +61,46 @@ struct type_list_head<type_list<Head, Tail...>> {
 template <typename List>
 using type_list_head_t = typename type_list_head<List>::type;
 
+template <typename T, typename List> struct type_list_contains;
+
+template <typename T>
+struct type_list_contains<T, type_list<>> : std::false_type {};
+
+template <typename T, typename Head, typename... Tail>
+struct type_list_contains<T, type_list<Head, Tail...>>
+    : std::bool_constant<std::is_same_v<T, Head> ||
+                         type_list_contains<T, type_list<Tail...>>::value> {};
+
+template <typename T, typename List>
+inline constexpr bool type_list_contains_v = type_list_contains<T, List>::value;
+
+namespace detail {
+template <typename Accumulated, typename Remaining>
+struct type_list_unique_impl;
+
+template <typename... Accumulated>
+struct type_list_unique_impl<type_list<Accumulated...>, type_list<>> {
+    using type = type_list<Accumulated...>;
+};
+
+template <typename... Accumulated, typename Head, typename... Tail>
+struct type_list_unique_impl<type_list<Accumulated...>,
+                             type_list<Head, Tail...>> {
+  private:
+    using next_accumulated = std::conditional_t<
+        type_list_contains_v<Head, type_list<Accumulated...>>,
+        type_list<Accumulated...>, type_list<Accumulated..., Head>>;
+
+  public:
+    using type = typename type_list_unique_impl<next_accumulated,
+                                                type_list<Tail...>>::type;
+};
+} // namespace detail
+
+template <typename List>
+using type_list_unique_t =
+    typename detail::type_list_unique_impl<type_list<>, List>::type;
+
 template <typename T> struct to_type_list {
     using type = T;
 };

--- a/test/type/type_list.cpp
+++ b/test/type/type_list.cpp
@@ -26,15 +26,22 @@ TEST(type_list_test, meta_utilities) {
     using nested_list =
         type_list<type_list_a, type_list<type_list_b, type_list_c>>;
 
-    static_assert(std::is_same_v<
-                  type_list_cat_t<type_list<type_list_a>,
-                                  type_list<type_list_b, type_list_c>,
-                                  type_list<>>,
-                  type_list<type_list_a, type_list_b, type_list_c>>);
+    static_assert(
+        std::is_same_v<
+            type_list_cat_t<type_list<type_list_a>,
+                            type_list<type_list_b, type_list_c>, type_list<>>,
+            type_list<type_list_a, type_list_b, type_list_c>>);
     static_assert(type_list_size_v<type_list<>> == 0);
     static_assert(type_list_size_v<nested_list> == 2);
     static_assert(std::is_same_v<type_list_head_t<nested_list>, type_list_a>);
     static_assert(std::is_same_v<to_type_list_t<nested_tuple>, nested_list>);
+    static_assert(type_list_contains_v<type_list_a, nested_list>);
+    static_assert(!type_list_contains_v<type_list_c, nested_list>);
+    static_assert(
+        std::is_same_v<
+            type_list_unique_t<type_list<type_list_a, type_list_b, type_list_a,
+                                         type_list_c, type_list_b>>,
+            type_list<type_list_a, type_list_b, type_list_c>>);
 }
 
 TEST(type_list_test, for_each_visits_types_in_order) {


### PR DESCRIPTION
## Summary
- add shared type_list_contains_v and type_list_unique_t utilities
- remove duplicate local type-list helper implementations from registration, static registry, and static graph code
- add static asserts covering contains and first-occurrence unique behavior

## Verification
- cmake --build build --target dingo_unit_test dingo_matrix_test_construct dingo_matrix_test_construct_invoke dingo_matrix_test_annotated dingo_matrix_test_runtime_container_regressions
- ctest --test-dir build --output-on-failure -R 'dingo_unit_test|dingo_matrix_test_(construct|construct_invoke|annotated|runtime_container_regressions)$|dingo_lit_tests'