### PR TITLE
Reduce duplicate collection key branching

### DIFF
--- a/include/dingo/container.h
+++ b/include/dingo/container.h
@@ -104,6 +104,13 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     template <typename T, typename Key>
     using static_selection_t = detail::static_binding_t<
         typename static_registry_type_::template bindings<T, Key>>;
+    template <typename Key>
+    using collection_key_t =
+        std::conditional_t<std::is_void_v<Key>, none_t, key<Key>>;
+
+    template <typename Key> static collection_key_t<Key> collection_key() {
+        return {};
+    }
 
     template <typename Request, typename Key>
     detail::binding_selection_status runtime_source_status() {
@@ -112,15 +119,9 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
 
     template <typename T, bool RemoveRvalueReferences, typename Key>
     decltype(auto) resolve_runtime_source(runtime_context& context) {
-        if constexpr (std::is_void_v<Key>) {
-            return resolve_runtime_only<
-                T, RemoveRvalueReferences, runtime_auto_constructible_v<T>>(
-                context, none_t{});
-        } else {
-            return resolve_runtime_only<
-                T, RemoveRvalueReferences, runtime_auto_constructible_v<T>>(
-                context, key<Key>{});
-        }
+        return resolve_runtime_only<T, RemoveRvalueReferences,
+                                    runtime_auto_constructible_v<T>>(
+            context, collection_key<Key>());
     }
 
     template <typename T>
@@ -144,13 +145,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         if (!runtime_registry_.has_runtime_registrations()) {
             return false;
         }
-        if constexpr (std::is_void_v<Key>) {
-            return runtime_registry_.template count_runtime_collection<T>(
-                       none_t{}) != 0;
-        } else {
-            return runtime_registry_.template count_runtime_collection<T>(
-                       key<Key>{}) != 0;
-        }
+        return runtime_registry_.template count_runtime_collection<T>(
+                   collection_key<Key>()) != 0;
     }
 
     bool has_runtime_registrations() const {
@@ -368,7 +364,7 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     }
 
     template <typename T, typename Key, typename Fn>
-    T construct_collection(runtime_context& context, Fn&& fn, key<Key>) {
+    T construct_collection_impl(runtime_context& context, Fn&& fn) {
         using collection_type = collection_traits<T>;
         using resolve_type = typename collection_type::resolve_type;
         binding_resolution_ref static_state_ref(
@@ -380,13 +376,13 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         return detail::construct_binding_collection<T>(
             [&] {
                 return runtime_registry_.template count_runtime_collection<T>(
-                    key<Key>{});
+                    collection_key<Key>());
             },
             [&] { return static_count; },
             [&](auto& results, auto&& append) {
                 runtime_registry_.append_runtime_collection(
                     results, context, std::forward<decltype(append)>(append),
-                    key<Key>{});
+                    collection_key<Key>());
             },
             [&](auto& results, auto&& append) {
                 static_state_ref.template append_static_collection<
@@ -397,34 +393,15 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             std::forward<Fn>(fn));
     }
 
+    template <typename T, typename Key, typename Fn>
+    T construct_collection(runtime_context& context, Fn&& fn, key<Key>) {
+        return construct_collection_impl<T, Key>(context, std::forward<Fn>(fn));
+    }
+
     template <typename T, typename Fn>
     T construct_collection(runtime_context& context, Fn&& fn, none_t) {
-        using collection_type = collection_traits<T>;
-        using resolve_type = typename collection_type::resolve_type;
-        binding_resolution_ref static_state_ref(
-            static_state_);
-
-        constexpr std::size_t static_count =
-            type_list_size_v<typename static_registry_type_::template bindings<
-                normalized_type_t<resolve_type>, void>>;
-        return detail::construct_binding_collection<T>(
-            [&] {
-                return runtime_registry_.template count_runtime_collection<T>(
-                    none_t{});
-            },
-            [&] { return static_count; },
-            [&](auto& results, auto&& append) {
-                runtime_registry_.append_runtime_collection(
-                    results, context, std::forward<decltype(append)>(append),
-                    none_t{});
-            },
-            [&](auto& results, auto&& append) {
-                static_state_ref.template append_static_collection<
-                    T, void, static_registry_type_>(
-                    results, *this, context,
-                    std::forward<decltype(append)>(append));
-            },
-            std::forward<Fn>(fn));
+        return construct_collection_impl<T, void>(context,
+                                                  std::forward<Fn>(fn));
     }
 
     template <typename LookupRequest, typename Request, typename Key,
@@ -473,9 +450,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     DINGO_ALWAYS_INLINE R resolve_static(Context& context) {
         if constexpr (collection_traits<R>::is_collection) {
-            return construct_static_collection<R>(
-                context,
-                std::conditional_t<std::is_void_v<Key>, none_t, key<Key>>{});
+            return construct_static_collection<R>(context,
+                                                  collection_key<Key>());
         } else {
             using lookup_request_type =
                 resolve_request_t<T, RemoveRvalueReferences>;
@@ -485,23 +461,13 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         }
     }
 
-    template <typename T, typename Fn>
+    template <typename T, typename Fn, typename IdType>
 #if defined(__GNUC__) && !defined(__clang__)
     __attribute__((noinline))
 #endif
-    T construct_collection_runtime_context(Fn&& fn, none_t) {
+    T construct_collection_runtime_context(Fn&& fn, IdType id) {
         runtime_context context;
-        return construct_collection<T>(context, std::forward<Fn>(fn), none_t{});
-    }
-
-    template <typename T, typename Fn, typename Key>
-#if defined(__GNUC__) && !defined(__clang__)
-    __attribute__((noinline))
-#endif
-    T construct_collection_runtime_context(Fn&& fn, key<Key>) {
-        runtime_context context;
-        return construct_collection<T>(context, std::forward<Fn>(fn),
-                                       key<Key>{});
+        return construct_collection<T>(context, std::forward<Fn>(fn), id);
     }
 
     template <typename T, bool RemoveRvalueReferences, bool MayAutoConstruct,
@@ -885,39 +851,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     template <typename T, typename Key = void, typename Fn>
     std::size_t append_collection(T& results, runtime_context& context,
                                   Fn&& fn) {
-        binding_resolution_ref static_state_ref(
-            static_state_);
-        if constexpr (std::is_void_v<Key>) {
-            return detail::append_binding_collection(
-                results,
-                [&](auto& collection, auto&& append) {
-                    return runtime_registry_.append_runtime_collection(
-                        collection, context,
-                        std::forward<decltype(append)>(append), none_t{});
-                },
-                [&](auto& collection, auto&& append) {
-                    return static_state_ref.template append_static_collection<
-                        T, void, static_registry_type_>(
-                        collection, *this, context,
-                        std::forward<decltype(append)>(append));
-                },
-                std::forward<Fn>(fn));
-        } else {
-            return detail::append_binding_collection(
-                results,
-                [&](auto& collection, auto&& append) {
-                    return runtime_registry_.append_runtime_collection(
-                        collection, context,
-                        std::forward<decltype(append)>(append), key<Key>{});
-                },
-                [&](auto& collection, auto&& append) {
-                    return static_state_ref.template append_static_collection<
-                        T, Key, static_registry_type_>(
-                        collection, *this, context,
-                        std::forward<decltype(append)>(append));
-                },
-                std::forward<Fn>(fn));
-        }
+        return append_collection_impl<T, Key>(results, context, context,
+                                              std::forward<Fn>(fn));
     }
 
     template <typename T, typename Key = void, typename Fn, typename Context,
@@ -925,71 +860,49 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
                                                runtime_context>,
                                int> = 0>
     std::size_t append_collection(T& results, Context& context, Fn&& fn) {
+        runtime_context runtime_append_context;
+        return append_collection_impl<T, Key>(
+            results, runtime_append_context, context, std::forward<Fn>(fn));
+    }
+
+    template <typename T, typename Key = void, typename Fn, typename Context>
+    std::size_t append_collection_impl(T& results,
+                                       runtime_context& runtime_context,
+                                       Context& static_context, Fn&& fn) {
         binding_resolution_ref static_state_ref(
             static_state_);
-        if constexpr (std::is_void_v<Key>) {
-            return detail::append_binding_collection(
-                results,
-                [&](auto& collection, auto&& append) {
-                    runtime_context runtime_context;
-                    return runtime_registry_.append_runtime_collection(
-                        collection, runtime_context,
-                        std::forward<decltype(append)>(append), none_t{});
-                },
-                [&](auto& collection, auto&& append) {
-                    return static_state_ref.template append_static_collection<
-                        T, void, static_registry_type_>(
-                        collection, *this, context,
-                        std::forward<decltype(append)>(append));
-                },
-                std::forward<Fn>(fn));
-        } else {
-            return detail::append_binding_collection(
-                results,
-                [&](auto& collection, auto&& append) {
-                    runtime_context runtime_context;
-                    return runtime_registry_.append_runtime_collection(
-                        collection, runtime_context,
-                        std::forward<decltype(append)>(append), key<Key>{});
-                },
-                [&](auto& collection, auto&& append) {
-                    return static_state_ref.template append_static_collection<
-                        T, Key, static_registry_type_>(
-                        collection, *this, context,
-                        std::forward<decltype(append)>(append));
-                },
-                std::forward<Fn>(fn));
-        }
+        return detail::append_binding_collection(
+            results,
+            [&](auto& collection, auto&& append) {
+                return runtime_registry_.append_runtime_collection(
+                    collection, runtime_context,
+                    std::forward<decltype(append)>(append),
+                    collection_key<Key>());
+            },
+            [&](auto& collection, auto&& append) {
+                return static_state_ref.template append_static_collection<
+                    T, Key, static_registry_type_>(
+                    collection, *this, static_context,
+                    std::forward<decltype(append)>(append));
+            },
+            std::forward<Fn>(fn));
     }
 
     template <typename T, typename Key = void> std::size_t count_collection() {
-        if constexpr (std::is_void_v<Key>) {
-            return detail::count_binding_collection<T>(
-                [&] {
-                    return runtime_registry_
-                        .template count_runtime_collection<T>(none_t{});
-                },
-                detail::static_collection_binding_count<static_registry_type_,
-                                                        T, void>());
-        } else {
-            return detail::count_binding_collection<T>(
-                [&] {
-                    return runtime_registry_
-                        .template count_runtime_collection<T>(key<Key>{});
-                },
-                detail::static_collection_binding_count<static_registry_type_,
-                                                        T, Key>());
-        }
+        return detail::count_binding_collection<T>(
+            [&] {
+                return runtime_registry_.template count_runtime_collection<T>(
+                    collection_key<Key>());
+            },
+            detail::static_collection_binding_count<static_registry_type_, T,
+                                                    Key>());
     }
 
     template <typename T, bool RemoveRvalueReferences, typename Key = void,
               typename R = resolve_request_t<T, RemoveRvalueReferences>>
     R resolve_request(runtime_context& context) {
-        if constexpr (std::is_void_v<Key>) {
-            return resolve<T, RemoveRvalueReferences>(context);
-        } else {
-            return resolve<T, RemoveRvalueReferences, true, Key>(context);
-        }
+        return resolve<T, RemoveRvalueReferences, true>(context,
+                                                        collection_key<Key>());
     }
 
     template <typename T, bool RemoveRvalueReferences, bool CheckCache = true,
@@ -1023,13 +936,9 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     R resolve(runtime_context& context) {
         if constexpr (collection_traits<R>::is_collection) {
-            if constexpr (std::is_void_v<Key>) {
-                return construct_collection<R>(
-                    context, detail::binding_collection_append{}, none_t{});
-            } else {
-                return construct_collection<R>(
-                    context, detail::binding_collection_append{}, key<Key>{});
-            }
+            return construct_collection<R>(context,
+                                           detail::binding_collection_append{},
+                                           collection_key<Key>());
         } else {
             using request_type = R;
             detail::runtime_binding_source<self_type, T, RemoveRvalueReferences,

--- a/include/dingo/runtime/registry.h
+++ b/include/dingo/runtime/registry.h
@@ -379,28 +379,18 @@ class runtime_registry : public allocator_base<Allocator> {
 
     template <typename T, typename Fn, typename Key>
     T construct_collection_runtime_request(Fn&& fn, key<Key>) {
-        using collection_type = collection_traits<T>;
-        using resolve_type = typename collection_type::resolve_type;
-
-        static_assert(collection_type::is_collection,
-                      "missing collection_traits specialization for type T");
-
-        T results;
-        runtime_context context;
-        const std::size_t keyed_count = count_runtime_collection<T>(key<Key>{});
-        if (keyed_count == 0) {
-            throw detail::make_collection_type_not_found_exception<
-                T, resolve_type>();
-        }
-
-        collection_type::reserve(results, keyed_count);
-        append_runtime_collection(results, context, std::forward<Fn>(fn),
-                                  key<Key>{});
-        return results;
+        return construct_collection_runtime_request_impl<T, Key>(
+            std::forward<Fn>(fn));
     }
 
     template <typename T, typename Fn>
     T construct_collection_runtime_request(Fn&& fn, none_t) {
+        return construct_collection_runtime_request_impl<T, void>(
+            std::forward<Fn>(fn));
+    }
+
+    template <typename T, typename Key, typename Fn>
+    T construct_collection_runtime_request_impl(Fn&& fn) {
         using collection_type = collection_traits<T>;
         using resolve_type = typename collection_type::resolve_type;
 
@@ -409,7 +399,8 @@ class runtime_registry : public allocator_base<Allocator> {
 
         T results;
         runtime_context context;
-        const std::size_t count = count_runtime_collection<T>(none_t{});
+        const std::size_t count =
+            count_runtime_collection<T>(collection_key<Key>());
         if (count == 0) {
             throw detail::make_collection_type_not_found_exception<
                 T, resolve_type>();
@@ -417,7 +408,7 @@ class runtime_registry : public allocator_base<Allocator> {
 
         collection_type::reserve(results, count);
         append_runtime_collection(results, context, std::forward<Fn>(fn),
-                                  none_t{});
+                                  collection_key<Key>());
         return results;
     }
 
@@ -436,8 +427,7 @@ class runtime_registry : public allocator_base<Allocator> {
 
     template <typename Request, typename Key = void>
     detail::binding_selection_status binding_status() {
-        return binding_status_for_id<Request>(
-            std::conditional_t<std::is_void_v<Key>, none_t, key<Key>>{});
+        return binding_status_for_id<Request>(collection_key<Key>());
     }
 
     template <typename Request, typename IdType>
@@ -460,31 +450,19 @@ class runtime_registry : public allocator_base<Allocator> {
     template <typename T, typename Key = void, typename Fn>
     std::size_t append_collection(T& results, runtime_context& context,
                                   Fn&& fn) {
-        if constexpr (std::is_void_v<Key>) {
-            return append_runtime_collection(results, context,
-                                             std::forward<Fn>(fn), none_t{});
-        } else {
-            return append_runtime_collection(results, context,
-                                             std::forward<Fn>(fn), key<Key>{});
-        }
+        return append_runtime_collection(results, context, std::forward<Fn>(fn),
+                                         collection_key<Key>());
     }
 
     template <typename T, typename Key = void> std::size_t count_collection() {
-        if constexpr (std::is_void_v<Key>) {
-            return count_runtime_collection<T>(none_t{});
-        } else {
-            return count_runtime_collection<T>(key<Key>{});
-        }
+        return count_runtime_collection<T>(collection_key<Key>());
     }
 
     template <typename T, bool RemoveRvalueReferences, typename Key = void,
               typename R = resolve_request_t<T, RemoveRvalueReferences>>
     R resolve_request(runtime_context& context) {
-        if constexpr (std::is_void_v<Key>) {
-            return resolve<T, RemoveRvalueReferences>(context, none_t{});
-        } else {
-            return resolve<T, RemoveRvalueReferences>(context, key<Key>{});
-        }
+        return resolve<T, RemoveRvalueReferences>(context,
+                                                  collection_key<Key>());
     }
 
     template <typename CachedT>
@@ -581,8 +559,15 @@ class runtime_registry : public allocator_base<Allocator> {
     using runtime_selection =
         detail::runtime_binding_selection<runtime_binding_interface_type,
                                           binding_cache_state*>;
+    template <typename Key>
+    using collection_key_t =
+        std::conditional_t<std::is_void_v<Key>, none_t, key<Key>>;
 
   protected:
+    template <typename Key> static collection_key_t<Key> collection_key() {
+        return {};
+    }
+
     template <typename Request, typename IdType = none_t>
     runtime_selection runtime_source_select(IdType&& id = IdType()) {
         using exact_type =
@@ -670,16 +655,35 @@ class runtime_registry : public allocator_base<Allocator> {
         }
     }
 
-    template <typename T, typename Key, typename Fn>
-    std::size_t append_runtime_collection(T& results, runtime_context& context,
-                                          Fn&& fn, key<Key>) {
+    template <typename T> runtime_type_bindings* runtime_collection_bindings() {
         using collection_type = collection_traits<T>;
         using resolve_type = typename collection_type::resolve_type;
         using lookup_type = normalized_type_t<resolve_type>;
 
         auto* state = runtime_bindings_if_present();
-        auto data =
-            state ? state->type_bindings.template get<lookup_type>() : nullptr;
+        return state ? state->type_bindings.template get<lookup_type>()
+                     : nullptr;
+    }
+
+    template <typename Entry>
+    static bool runtime_collection_entry_matches(const Entry&, none_t) {
+        return true;
+    }
+
+    template <typename Entry, typename Key>
+    static bool runtime_collection_entry_matches(const Entry& entry, key<Key>) {
+        return entry.key_type &&
+               *entry.key_type ==
+                   rtti_type::template get_type_index<key<Key>>();
+    }
+
+    template <typename T, typename Fn, typename IdType>
+    std::size_t append_runtime_collection(T& results, runtime_context& context,
+                                          Fn&& fn, IdType id) {
+        using collection_type = collection_traits<T>;
+        using resolve_type = typename collection_type::resolve_type;
+
+        auto data = runtime_collection_bindings<T>();
         if (!data) {
             return 0;
         }
@@ -687,77 +691,35 @@ class runtime_registry : public allocator_base<Allocator> {
         std::size_t count = 0;
         for (auto&& p : data->bindings) {
             auto& entry = p.second;
-            if (entry.key_type &&
-                *entry.key_type ==
-                    rtti_type::template get_type_index<key<Key>>()) {
-                ++count;
-                fn(results, resolve_collection_type<resolve_type>(
-                                *entry.binding, context));
+            if (!runtime_collection_entry_matches(entry, id)) {
+                continue;
             }
-        }
-
-        return count;
-    }
-
-    template <typename T, typename Fn>
-    std::size_t append_runtime_collection(T& results, runtime_context& context,
-                                          Fn&& fn, none_t) {
-        using collection_type = collection_traits<T>;
-        using resolve_type = typename collection_type::resolve_type;
-        using lookup_type = normalized_type_t<resolve_type>;
-
-        auto* state = runtime_bindings_if_present();
-        auto data =
-            state ? state->type_bindings.template get<lookup_type>() : nullptr;
-        if (!data) {
-            return 0;
-        }
-
-        std::size_t count = 0;
-        for (auto&& p : data->bindings) {
             ++count;
-            fn(results, resolve_collection_type<resolve_type>(*p.second.binding,
-                                                              context));
+            fn(results,
+               resolve_collection_type<resolve_type>(*entry.binding, context));
         }
 
         return count;
     }
 
-    template <typename T, typename Key>
-    std::size_t count_runtime_collection(key<Key>) {
-        using collection_type = collection_traits<T>;
-        using resolve_type = typename collection_type::resolve_type;
-        using lookup_type = normalized_type_t<resolve_type>;
-
-        auto* state = runtime_bindings_if_present();
-        auto data =
-            state ? state->type_bindings.template get<lookup_type>() : nullptr;
+    template <typename T, typename IdType>
+    std::size_t count_runtime_collection(IdType id) {
+        auto data = runtime_collection_bindings<T>();
         if (!data) {
             return 0;
         }
 
+        if constexpr (is_none_v<std::decay_t<IdType>>) {
+            return data->bindings.size();
+        }
+
         std::size_t count = 0;
         for (auto&& p : data->bindings) {
-            auto& entry = p.second;
-            if (entry.key_type &&
-                *entry.key_type ==
-                    rtti_type::template get_type_index<key<Key>>()) {
+            if (runtime_collection_entry_matches(p.second, id)) {
                 ++count;
             }
         }
-
         return count;
-    }
-
-    template <typename T> std::size_t count_runtime_collection(none_t) {
-        using collection_type = collection_traits<T>;
-        using resolve_type = typename collection_type::resolve_type;
-        using lookup_type = normalized_type_t<resolve_type>;
-
-        auto* state = runtime_bindings_if_present();
-        auto data =
-            state ? state->type_bindings.template get<lookup_type>() : nullptr;
-        return data ? data->bindings.size() : 0;
     }
 
   private:


### PR DESCRIPTION
## Summary
- add shared collection-key helpers for keyed/unkeyed runtime collection paths
- collapse repeated keyed versus unkeyed branches in container and runtime registry collection operations
- keep runtime dispatch behavior unchanged while reducing local duplication

## Verification
- cmake --build build --target dingo_unit_test dingo_matrix_test_construct dingo_matrix_test_construct_invoke dingo_matrix_test_runtime_container_regressions
- ctest --test-dir build --output-on-failure -R 'dingo_unit_test|dingo_matrix_test_(construct|construct_invoke|runtime_container_regressions)$|dingo_lit_tests'