### PR TITLE
Clarify distinct conversion storage costs

### DIFF
--- a/include/dingo/storage/type_storage_traits.h
+++ b/include/dingo/storage/type_storage_traits.h
@@ -71,93 +71,97 @@ struct combined_storage_types {
     using rvalue_reference_types =
         type_list_cat_t<typename AccessTraits::rvalue_reference_types,
                         typename ResolutionTraits::rvalue_reference_types>;
-    using pointer_types = type_list_cat_t<typename AccessTraits::pointer_types,
-                                          typename ResolutionTraits::pointer_types>;
+    using pointer_types =
+        type_list_cat_t<typename AccessTraits::pointer_types,
+                        typename ResolutionTraits::pointer_types>;
     using conversion_types =
         type_list_cat_t<typename AccessTraits::conversion_types,
                         typename ResolutionTraits::conversion_types>;
 };
 
-template <typename T, typename List> struct type_list_contains_distinct;
+template <typename T>
+using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+template <typename T, typename List> struct has_distinct_conversion_type;
 
 template <typename T>
-struct type_list_contains_distinct<T, type_list<>> : std::false_type {};
+struct has_distinct_conversion_type<T, type_list<>> : std::false_type {};
 
 template <typename T, typename Head, typename... Tail>
-struct type_list_contains_distinct<T, type_list<Head, Tail...>>
+struct has_distinct_conversion_type<T, type_list<Head, Tail...>>
     : std::bool_constant<
-          !std::is_same_v<T, std::remove_cv_t<std::remove_reference_t<Head>>> ||
-          type_list_contains_distinct<T, type_list<Tail...>>::value> {};
+          !std::is_same_v<T, remove_cvref_t<Head>> ||
+          has_distinct_conversion_type<T, type_list<Tail...>>::value> {};
 
 template <typename T, typename List>
-inline constexpr bool type_list_contains_distinct_v =
-    type_list_contains_distinct<T, List>::value;
+inline constexpr bool has_distinct_conversion_type_v =
+    has_distinct_conversion_type<T, List>::value;
 
-template <typename T, typename List> struct type_list_max_distinct_size;
+template <typename T, typename List> struct max_distinct_conversion_size;
 
 template <typename T>
-struct type_list_max_distinct_size<T, type_list<>>
+struct max_distinct_conversion_size<T, type_list<>>
     : std::integral_constant<std::size_t, 0> {};
 
 template <typename T, typename Head, typename... Tail>
-struct type_list_max_distinct_size<T, type_list<Head, Tail...>>
+struct max_distinct_conversion_size<T, type_list<Head, Tail...>>
     : std::integral_constant<
           std::size_t,
-          !std::is_same_v<T, std::remove_cv_t<std::remove_reference_t<Head>>>
-              ? (sizeof(std::remove_cv_t<std::remove_reference_t<Head>>) >
-                         type_list_max_distinct_size<T,
-                                                     type_list<Tail...>>::value
-                     ? sizeof(std::remove_cv_t<std::remove_reference_t<Head>>)
-                     : type_list_max_distinct_size<T,
-                                                   type_list<Tail...>>::value)
-              : type_list_max_distinct_size<T, type_list<Tail...>>::value> {};
-
-template <typename T, typename List>
-inline constexpr std::size_t type_list_max_distinct_size_v =
-    type_list_max_distinct_size<T, List>::value;
-
-template <typename T, typename List> struct type_list_max_distinct_align;
-
-template <typename T>
-struct type_list_max_distinct_align<T, type_list<>>
-    : std::integral_constant<std::size_t, 0> {};
-
-template <typename T, typename Head, typename... Tail>
-struct type_list_max_distinct_align<T, type_list<Head, Tail...>>
-    : std::integral_constant<
-          std::size_t,
-          !std::is_same_v<T, std::remove_cv_t<std::remove_reference_t<Head>>>
-              ? (alignof(std::remove_cv_t<std::remove_reference_t<Head>>) >
-                         type_list_max_distinct_align<T,
+          !std::is_same_v<T, remove_cvref_t<Head>>
+              ? (sizeof(remove_cvref_t<Head>) >
+                         max_distinct_conversion_size<T,
                                                       type_list<Tail...>>::value
-                     ? alignof(std::remove_cv_t<std::remove_reference_t<Head>>)
-                     : type_list_max_distinct_align<T,
+                     ? sizeof(remove_cvref_t<Head>)
+                     : max_distinct_conversion_size<T,
                                                     type_list<Tail...>>::value)
-              : type_list_max_distinct_align<T, type_list<Tail...>>::value> {};
+              : max_distinct_conversion_size<T, type_list<Tail...>>::value> {};
 
 template <typename T, typename List>
-inline constexpr std::size_t type_list_max_distinct_align_v =
-    type_list_max_distinct_align<T, List>::value;
+inline constexpr std::size_t max_distinct_conversion_size_v =
+    max_distinct_conversion_size<T, List>::value;
 
-template <typename T, typename List>
-struct type_list_has_nontrivial_distinct_destructor;
+template <typename T, typename List> struct max_distinct_conversion_align;
 
 template <typename T>
-struct type_list_has_nontrivial_distinct_destructor<T, type_list<>>
+struct max_distinct_conversion_align<T, type_list<>>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename T, typename Head, typename... Tail>
+struct max_distinct_conversion_align<T, type_list<Head, Tail...>>
+    : std::integral_constant<
+          std::size_t,
+          !std::is_same_v<T, remove_cvref_t<Head>>
+              ? (alignof(remove_cvref_t<Head>) >
+                         max_distinct_conversion_align<
+                             T, type_list<Tail...>>::value
+                     ? alignof(remove_cvref_t<Head>)
+                     : max_distinct_conversion_align<T,
+                                                     type_list<Tail...>>::value)
+              : max_distinct_conversion_align<T, type_list<Tail...>>::value> {};
+
+template <typename T, typename List>
+inline constexpr std::size_t max_distinct_conversion_align_v =
+    max_distinct_conversion_align<T, List>::value;
+
+template <typename T, typename List>
+struct has_nontrivial_distinct_conversion_destructor;
+
+template <typename T>
+struct has_nontrivial_distinct_conversion_destructor<T, type_list<>>
     : std::false_type {};
 
 template <typename T, typename Head, typename... Tail>
-struct type_list_has_nontrivial_distinct_destructor<T, type_list<Head, Tail...>>
+struct has_nontrivial_distinct_conversion_destructor<T,
+                                                     type_list<Head, Tail...>>
     : std::bool_constant<
-          (!std::is_same_v<T, std::remove_cv_t<std::remove_reference_t<Head>>> &&
-           !std::is_trivially_destructible_v<
-               std::remove_cv_t<std::remove_reference_t<Head>>>) ||
-          type_list_has_nontrivial_distinct_destructor<
+          (!std::is_same_v<T, remove_cvref_t<Head>> &&
+           !std::is_trivially_destructible_v<remove_cvref_t<Head>>) ||
+          has_nontrivial_distinct_conversion_destructor<
               T, type_list<Tail...>>::value> {};
 
 template <typename T, typename List>
-inline constexpr bool type_list_has_nontrivial_distinct_destructor_v =
-    type_list_has_nontrivial_distinct_destructor<T, List>::value;
+inline constexpr bool has_nontrivial_distinct_conversion_destructor_v =
+    has_nontrivial_distinct_conversion_destructor<T, List>::value;
 
 template <typename Storage, typename = void>
 struct static_conversion_temporary_slots_base
@@ -272,39 +276,34 @@ template <typename StorageTag, typename Type, typename U>
 struct type_storage_traits<
     StorageTag, Type, U,
     std::enable_if_t<storage_traits<StorageTag, Type, U>::enabled>>
-    : detail::combined_storage_types<
-          storage_traits<StorageTag, Type, U>,
-          resolution_traits<StorageTag, Type, U>> {
+    : detail::combined_storage_types<storage_traits<StorageTag, Type, U>,
+                                     resolution_traits<StorageTag, Type, U>> {
   private:
-    using combined_types = detail::combined_storage_types<
-        storage_traits<StorageTag, Type, U>,
-        resolution_traits<StorageTag, Type, U>>;
+    using combined_types =
+        detail::combined_storage_types<storage_traits<StorageTag, Type, U>,
+                                       resolution_traits<StorageTag, Type, U>>;
 
   public:
     static constexpr bool is_stable =
         storage_traits<StorageTag, Type, U>::is_stable;
     static constexpr std::size_t static_conversion_temporary_slots =
-        detail::type_list_contains_distinct_v<
-            Type,
-            typename combined_types::conversion_types> &&
+        detail::has_distinct_conversion_type_v<
+            Type, typename combined_types::conversion_types> &&
                 !is_stable
             ? 1
             : 0;
     static constexpr std::size_t static_conversion_temporary_size =
-        !is_stable
-            ? detail::type_list_max_distinct_size_v<
-                  Type, typename combined_types::conversion_types>
-            : 0;
+        !is_stable ? detail::max_distinct_conversion_size_v<
+                         Type, typename combined_types::conversion_types>
+                   : 0;
     static constexpr std::size_t static_conversion_temporary_align =
-        !is_stable
-            ? detail::type_list_max_distinct_align_v<
-                  Type, typename combined_types::conversion_types>
-            : 0;
+        !is_stable ? detail::max_distinct_conversion_align_v<
+                         Type, typename combined_types::conversion_types>
+                   : 0;
     static constexpr std::size_t static_conversion_destructible_slots =
-            !is_stable &&
-                    detail::type_list_has_nontrivial_distinct_destructor_v<
-                        Type, typename combined_types::conversion_types>
-                ? 1
-                : 0;
+        !is_stable && detail::has_nontrivial_distinct_conversion_destructor_v<
+                          Type, typename combined_types::conversion_types>
+            ? 1
+            : 0;
 };
 } // namespace dingo

--- a/test/registration/binding_graph.cpp
+++ b/test/registration/binding_graph.cpp
@@ -18,6 +18,35 @@
 
 using namespace dingo;
 
+namespace {
+struct same_conversion_storage_tag {};
+struct larger_conversion_storage_tag {};
+} // namespace
+
+template <typename Type, typename U>
+struct dingo::storage_traits<same_conversion_storage_tag, Type, U> {
+    static constexpr bool enabled = true;
+    static constexpr bool is_stable = false;
+
+    using value_types = type_list<Type>;
+    using lvalue_reference_types = type_list<>;
+    using rvalue_reference_types = type_list<>;
+    using pointer_types = type_list<>;
+    using conversion_types = type_list<Type>;
+};
+
+template <typename Type, typename U>
+struct dingo::storage_traits<larger_conversion_storage_tag, Type, U> {
+    static constexpr bool enabled = true;
+    static constexpr bool is_stable = false;
+
+    using value_types = type_list<Type>;
+    using lvalue_reference_types = type_list<>;
+    using rvalue_reference_types = type_list<>;
+    using pointer_types = type_list<>;
+    using conversion_types = type_list<U>;
+};
+
 TEST(static_graph_test, exposes_dependency_nodes_and_topological_order) {
     struct config {};
     struct service_interface {
@@ -147,35 +176,57 @@ TEST(static_execution_traits_test,
     struct payload {
         ~payload() {}
     };
+    struct larger_payload {
+        alignas(16) char bytes[32];
+    };
 
     using unique_value_storage = detail::conversions<unique, payload, payload>;
+    using unique_same_value_storage =
+        type_storage_traits<same_conversion_storage_tag, payload, payload>;
+    using unique_larger_value_storage =
+        type_storage_traits<larger_conversion_storage_tag, payload,
+                            larger_payload>;
     using unique_handle_storage =
         detail::conversions<unique, std::shared_ptr<payload>, payload>;
     using shared_handle_storage =
         detail::conversions<shared, std::shared_ptr<payload>, payload>;
 
+    static_assert(unique_value_storage::static_conversion_temporary_slots == 1);
+    static_assert(unique_value_storage::static_conversion_destructible_slots ==
+                  1);
+    static_assert(unique_value_storage::static_conversion_temporary_size ==
+                  sizeof(std::optional<payload>));
+    static_assert(unique_value_storage::static_conversion_temporary_align ==
+                  alignof(std::optional<payload>));
     static_assert(
-        unique_value_storage::static_conversion_temporary_slots == 1);
+        unique_same_value_storage::static_conversion_temporary_slots == 0);
     static_assert(
-        unique_value_storage::static_conversion_destructible_slots == 1);
+        unique_same_value_storage::static_conversion_destructible_slots == 0);
+    static_assert(unique_same_value_storage::static_conversion_temporary_size ==
+                  0);
     static_assert(
-        unique_value_storage::static_conversion_temporary_size ==
-        sizeof(std::optional<payload>));
+        unique_same_value_storage::static_conversion_temporary_align == 0);
     static_assert(
-        unique_value_storage::static_conversion_temporary_align ==
-        alignof(std::optional<payload>));
+        unique_larger_value_storage::static_conversion_temporary_slots == 1);
     static_assert(
-        unique_handle_storage::static_conversion_temporary_slots == 0);
+        unique_larger_value_storage::static_conversion_destructible_slots == 0);
     static_assert(
-        unique_handle_storage::static_conversion_destructible_slots == 0);
+        unique_larger_value_storage::static_conversion_temporary_size ==
+        sizeof(larger_payload));
     static_assert(
-        unique_handle_storage::static_conversion_temporary_size == 0);
-    static_assert(
-        unique_handle_storage::static_conversion_temporary_align == 0);
-    static_assert(
-        shared_handle_storage::static_conversion_temporary_slots == 0);
-    static_assert(
-        shared_handle_storage::static_conversion_destructible_slots == 0);
+        unique_larger_value_storage::static_conversion_temporary_align ==
+        alignof(larger_payload));
+    static_assert(unique_handle_storage::static_conversion_temporary_slots ==
+                  0);
+    static_assert(unique_handle_storage::static_conversion_destructible_slots ==
+                  0);
+    static_assert(unique_handle_storage::static_conversion_temporary_size == 0);
+    static_assert(unique_handle_storage::static_conversion_temporary_align ==
+                  0);
+    static_assert(shared_handle_storage::static_conversion_temporary_slots ==
+                  0);
+    static_assert(shared_handle_storage::static_conversion_destructible_slots ==
+                  0);
     static_assert(
         shared_handle_storage::static_conversion_temporary_size == 0);
     static_assert(


### PR DESCRIPTION
## Summary
- Rename distinct conversion storage helpers around their actual static conversion policy
- Add behavior locks for same-type and larger conversion temporary accounting
- Reduce repeated cv/ref stripping in the helper implementations

## Verification
- cmake --build build --target dingo_unit_test
- ctest --test-dir build --output-on-failure -R '^dingo_unit_test$'
- focused unit, matrix construct, matrix construct_invoke, and lit test gate
- clang-format -n -Werror on touched ranges
- git diff --check