### PR TITLE
Infer repeated static dependency request shapes

### DIFF
--- a/include/dingo/static/registry.h
+++ b/include/dingo/static/registry.h
@@ -122,31 +122,63 @@ template <typename Request> struct binding_request_converter {
     operator Request() const;
 };
 
-template <typename RequestTypes> struct binding_argument_placeholder;
-
-template <typename... RequestTypes>
-struct binding_argument_placeholder<type_list<RequestTypes...>>
-    : binding_request_converter<RequestTypes>... {};
-
-template <typename RequestTypes>
-using binding_argument_placeholder_t =
-    binding_argument_placeholder<RequestTypes>;
-
 template <typename Implementation, typename BindingTuple>
 struct binding_tuple_constructible;
+
+template <typename Implementation, typename SelectedRequests,
+          typename BindingTuple>
+struct binding_tuple_request_constructible;
+
+template <typename Implementation, typename SelectedRequests,
+          typename RequestTypes, typename RemainingBindings>
+struct binding_request_options_constructible;
+
+template <typename Implementation, typename... SelectedRequests>
+struct binding_tuple_request_constructible<Implementation,
+                                           type_list<SelectedRequests...>,
+                                           type_list<>>
+    : std::bool_constant<
+          is_list_initializable_v<
+              Implementation,
+              binding_request_converter<SelectedRequests>...> ||
+          is_direct_initializable_v<
+              Implementation,
+              binding_request_converter<SelectedRequests>...>> {};
+
+template <typename Implementation, typename... SelectedRequests, typename Head,
+          typename... Tail>
+struct binding_tuple_request_constructible<Implementation,
+                                           type_list<SelectedRequests...>,
+                                           type_list<Head, Tail...>>
+    : binding_request_options_constructible<
+          Implementation, type_list<SelectedRequests...>,
+          typename binding_request_types<Head>::type, type_list<Tail...>> {};
+
+template <typename Implementation, typename SelectedRequests,
+          typename RemainingBindings>
+struct binding_request_options_constructible<Implementation, SelectedRequests,
+                                             type_list<>,
+                                             RemainingBindings>
+    : std::false_type {};
+
+template <typename Implementation, typename... SelectedRequests,
+          typename Request, typename... Requests, typename RemainingBindings>
+struct binding_request_options_constructible<
+    Implementation, type_list<SelectedRequests...>, type_list<Request, Requests...>,
+    RemainingBindings>
+    : std::bool_constant<
+          binding_tuple_request_constructible<
+              Implementation, type_list<SelectedRequests..., Request>,
+              RemainingBindings>::value ||
+          binding_request_options_constructible<
+              Implementation, type_list<SelectedRequests...>,
+              type_list<Requests...>, RemainingBindings>::value> {};
 
 template <typename Implementation, typename... InterfaceBindings>
 struct binding_tuple_constructible<Implementation,
                                    type_list<InterfaceBindings...>>
-    : std::bool_constant<
-          is_list_initializable_v<Implementation,
-                                  binding_argument_placeholder_t<
-                                      typename binding_request_types<
-                                          InterfaceBindings>::type>...> ||
-          is_direct_initializable_v<
-              Implementation, binding_argument_placeholder_t<
-                                  typename binding_request_types<
-                                      InterfaceBindings>::type>...>> {};
+    : binding_tuple_request_constructible<Implementation, type_list<>,
+                                          type_list<InterfaceBindings...>> {};
 
 template <typename InterfaceBindings, size_t Arity, typename = void>
 struct binding_tuples;

--- a/test/registration/static_bindings_source.cpp
+++ b/test/registration/static_bindings_source.cpp
@@ -98,6 +98,27 @@ TEST(static_bindings_source_test,
                                  typename registry_type::binding<logger>>>);
 }
 
+TEST(static_bindings_source_test,
+     inferred_dependencies_can_reuse_one_binding_for_multiple_request_shapes) {
+    struct config {};
+    struct service {
+        service(config&, std::shared_ptr<config>) {}
+    };
+
+    using source = dingo::bindings<
+        dingo::bind<scope<shared>, storage<std::shared_ptr<config>>>,
+        dingo::bind<scope<unique>, storage<service>>>;
+    using registry_type = typename source::type;
+
+    static_assert(registry_type::valid);
+    static_assert(std::is_same_v<typename registry_type::dependencies<service>,
+                                 void>);
+    static_assert(
+        std::is_same_v<typename registry_type::dependency_bindings<service>,
+                       type_list<typename registry_type::binding<config>,
+                                 typename registry_type::binding<config>>>);
+}
+
 TEST(static_bindings_source_test, annotated_dependencies_normalize_to_annotated_interfaces) {
     struct service_tag {};
     struct config_tag {};


### PR DESCRIPTION
## Summary
- fix static constructor dependency inference when one binding satisfies multiple request shapes
- replace the all-conversions placeholder with an explicit request-shape search per constructor slot
- add a regression for config& plus std::shared_ptr<config> from one shared binding

## Verification
- cmake --build build --target dingo_unit_test
- ctest --test-dir build --output-on-failure -R dingo_unit_test
- ctest --test-dir build --output-on-failure -R dingo_lit_tests
- git diff --check --cached