### PR TITLE
Support static parent fallback across container shapes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,7 @@ if(DINGO_DEVELOPMENT_MODE)
             test/index/index.cpp
             test/registration/binding_graph.cpp
             test/registration/static_bindings_source.cpp
+            test/registration/static_parent_container.cpp
             test/registration/type_registration.cpp
             test/storage/shared_type_conversion.cpp
             test/container/construct_common.h

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -235,9 +235,9 @@ See:
 
 Containers can form a parent-child hierarchy. Resolution walks from the child
 toward the parent chain, which allows local overrides on top of broader shared
-configuration. Runtime-only containers use `container<> child(&parent)`.
-Mixed static/runtime containers use `container<bindings<...>, Parent>` and
-construct the child with `child(&parent)`. Purely static containers use
+configuration. Runtime-only containers use `container<> child(&parent)`. Mixed
+static/runtime containers use `container<bindings<...>, Parent>` and construct
+the child with `child(&parent)`. Purely static containers use
 `static_container<bindings<...>, Parent>` the same way. Static bindings in the
 child can resolve missing dependencies from the parent's static or runtime
 graph.

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -235,7 +235,12 @@ See:
 
 Containers can form a parent-child hierarchy. Resolution walks from the child
 toward the parent chain, which allows local overrides on top of broader shared
-configuration.
+configuration. Runtime-only containers use `container<> child(&parent)`.
+Mixed static/runtime containers use `container<bindings<...>, Parent>` and
+construct the child with `child(&parent)`. Purely static containers use
+`static_container<bindings<...>, Parent>` the same way. Static bindings in the
+child can resolve missing dependencies from the parent's static or runtime
+graph.
 
 Nesting is most useful for:
 

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -77,6 +77,11 @@ neither source is an override of the other.
 A request for a collection can use both sources. Runtime and static matches are
 merged into the returned collection.
 
+Parent containers are another fallback source. `container<bindings<...>, Parent>`
+and `static_container<bindings<...>, Parent>` keep the child graph local first:
+a child static or runtime binding wins for singular requests, and a missing
+child dependency can be resolved from the parent graph.
+
 Local `bindings<...>` on a registration are different: they describe the private
 dependencies used while building that registered type. For a single dependency,
 the local binding is checked before the host container. For a dependency

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -77,10 +77,11 @@ neither source is an override of the other.
 A request for a collection can use both sources. Runtime and static matches are
 merged into the returned collection.
 
-Parent containers are another fallback source. `container<bindings<...>, Parent>`
-and `static_container<bindings<...>, Parent>` keep the child graph local first:
-a child static or runtime binding wins for singular requests, and a missing
-child dependency can be resolved from the parent graph.
+Parent containers are another fallback source.
+`container<bindings<...>, Parent>` and `static_container<bindings<...>, Parent>`
+keep the child graph local first: a child static or runtime binding wins for
+singular requests, and a missing child dependency can be resolved from the
+parent graph.
 
 Local `bindings<...>` on a registration are different: they describe the private
 dependencies used while building that registered type. For a single dependency,

--- a/include/dingo/container.h
+++ b/include/dingo/container.h
@@ -50,6 +50,7 @@
 #include <optional>
 #include <type_traits>
 #include <typeindex>
+#include <utility>
 #include <variant>
 
 #ifdef _MSC_VER
@@ -73,13 +74,40 @@ template <typename T>
 inline constexpr bool is_static_context_argument_v =
     is_static_context_argument<
         std::remove_cv_t<std::remove_reference_t<T>>>::value;
+
+template <typename Parent, typename T, bool RemoveRvalueReferences,
+          bool CheckCache, typename Key, typename = void>
+struct parent_context_resolve_supported : std::false_type {};
+
+template <typename Parent, typename T, bool RemoveRvalueReferences,
+          bool CheckCache>
+struct parent_context_resolve_supported<
+    Parent, T, RemoveRvalueReferences, CheckCache, void,
+    std::void_t<decltype(std::declval<Parent&>().template resolve<
+                         T, RemoveRvalueReferences, CheckCache>(
+        std::declval<runtime_context&>()))>> : std::true_type {};
+
+template <typename Parent, typename T, bool RemoveRvalueReferences,
+          bool CheckCache, typename Key>
+struct parent_context_resolve_supported<
+    Parent, T, RemoveRvalueReferences, CheckCache, Key,
+    std::void_t<decltype(std::declval<Parent&>().template resolve<
+                         T, RemoveRvalueReferences, CheckCache>(
+        std::declval<runtime_context&>(), key<Key>{}))>> : std::true_type {};
+
+template <typename Parent, typename T, bool RemoveRvalueReferences,
+          bool CheckCache, typename Key>
+inline constexpr bool parent_context_resolve_supported_v =
+    parent_context_resolve_supported<Parent, T, RemoveRvalueReferences,
+                                     CheckCache, Key>::value;
 } // namespace detail
 
-template <typename... Registrations>
-class detail::container_with_static_bindings<static_registry<Registrations...>>
+template <typename ParentContainer, typename... Registrations>
+class detail::container_with_static_bindings<static_registry<Registrations...>,
+                                             ParentContainer>
     : public detail::runtime_registration_api<
           detail::container_with_static_bindings<
-              static_registry<Registrations...>>> {
+              static_registry<Registrations...>, ParentContainer>> {
     friend class runtime_context;
     template <typename, typename, bool, typename, typename>
     friend struct detail::runtime_binding_source;
@@ -89,7 +117,9 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     friend struct detail::static_binding_source;
 
     using static_registry_type_ = static_registry<Registrations...>;
-    using self_type = detail::container_with_static_bindings<static_registry_type_>;
+    using self_type =
+        detail::container_with_static_bindings<static_registry_type_,
+                                               ParentContainer>;
     using runtime_base =
         runtime_registry<dynamic_container_traits,
                          typename dynamic_container_traits::allocator_type,
@@ -100,6 +130,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     using binding_resolution_ref =
         detail::binding_scope_ref<static_state, Registrations...>;
     using static_context_type = static_context<static_registry_type_>;
+    static constexpr bool has_parent_v = !std::is_void_v<ParentContainer>;
+    using parent_container_type = ParentContainer;
 
     template <typename T, typename Key>
     using static_selection_t = detail::static_binding_t<
@@ -165,9 +197,10 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     template <typename Request, typename Key>
     struct static_binding_satisfies_request<Request, Key, true>
         : std::bool_constant<
-              detail::static_binding_resolvable_v<
-                  typename static_selection_t<Request, Key>::binding_type,
-                  static_registry_type_> &&
+              (has_parent_v ||
+               detail::static_binding_resolvable_v<
+                   typename static_selection_t<Request, Key>::binding_type,
+                   static_registry_type_>) &&
               detail::binding_supports_request_v<
                   request_interface_t<Request>,
                   typename static_selection_t<Request, Key>::binding_type>> {};
@@ -186,6 +219,16 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             return !has_runtime_binding<Request, Key>();
         }
     }
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void>
+    static constexpr bool has_static_resolve_request_v =
+        static_binding_satisfies_request_v<
+            resolve_request_t<T, RemoveRvalueReferences>, Key>;
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void>
+    static constexpr detail::binding_selection_status static_resolve_status_v =
+        static_selection_t<resolve_request_t<T, RemoveRvalueReferences>,
+                           Key>::status;
 
     template <typename Collection, typename Key = void>
     bool select_static_collection() {
@@ -246,6 +289,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
 
     template <typename Collection, typename Key = void>
     static constexpr bool has_static_collection_v =
+        detail::static_collection_binding_count<static_registry_type_,
+                                                Collection, Key>() != 0 &&
         detail::static_bindings_resolvable_v<
             typename static_registry_type_::template bindings<
                 normalized_type_t<
@@ -412,7 +457,14 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         using binding = typename selection::binding_type;
         if constexpr (selection::status !=
                       detail::binding_selection_status::found) {
-            throw detail::make_type_not_found_exception<LookupRequest>(context);
+            if constexpr (selection::status ==
+                          detail::binding_selection_status::ambiguous) {
+                throw detail::make_type_ambiguous_exception<LookupRequest>(
+                    context);
+            } else {
+                throw detail::make_type_not_found_exception<LookupRequest>(
+                    context);
+            }
         } else {
             static_resolution_ref static_state_ref(
                 static_state_);
@@ -429,7 +481,12 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         using binding = typename selection::binding_type;
         if constexpr (selection::status !=
                       detail::binding_selection_status::found) {
-            throw detail::make_type_not_found_exception<Request>(context);
+            if constexpr (selection::status ==
+                          detail::binding_selection_status::ambiguous) {
+                throw detail::make_type_ambiguous_exception<Request>(context);
+            } else {
+                throw detail::make_type_not_found_exception<Request>(context);
+            }
         } else {
             binding_resolution_ref static_state_ref(
                 static_state_);
@@ -520,6 +577,35 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             missing{*this, id};
         auto sources = detail::make_selected_binding_sources(selected, missing);
         return detail::resolve_from_binding_sources<T, R>(context, sources);
+    }
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void,
+              typename R = resolve_result_t<T, RemoveRvalueReferences>>
+    R resolve_parent(none_t = {}) {
+        if constexpr (std::is_void_v<Key>) {
+            return parent_->template resolve<T>();
+        } else {
+            return parent_->template resolve<T>(key<Key>{});
+        }
+    }
+
+    template <typename T, bool RemoveRvalueReferences, bool CheckCache,
+              typename Key = void,
+              typename R = resolve_request_t<T, RemoveRvalueReferences>>
+    R resolve_parent(runtime_context& context) {
+        if constexpr (detail::parent_context_resolve_supported_v<
+                          parent_container_type, T, RemoveRvalueReferences,
+                          CheckCache, Key>) {
+            if constexpr (std::is_void_v<Key>) {
+                return parent_->template resolve<T, RemoveRvalueReferences,
+                                                 CheckCache>(context);
+            } else {
+                return parent_->template resolve<T, RemoveRvalueReferences,
+                                                 CheckCache>(context, key<Key>{});
+            }
+        } else {
+            return resolve_parent<T, RemoveRvalueReferences, Key>();
+        }
     }
 
     template <typename T, bool RemoveRvalueReferences, bool MayAutoConstruct,
@@ -626,16 +712,25 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     explicit container_with_static_bindings(allocator_type alloc)
         : runtime_registry_(nullptr, alloc) {}
 
+    template <typename Parent = ParentContainer,
+              std::enable_if_t<!std::is_void_v<Parent>, int> = 0>
+    explicit container_with_static_bindings(Parent* parent,
+                                            allocator_type alloc =
+                                                allocator_type())
+        : runtime_registry_(nullptr, alloc), parent_(parent) {}
+
     container_with_static_bindings(const self_type& other)
         : runtime_registry_(other.runtime_registry_),
           static_registry_(other.static_registry_),
-          static_state_(other.static_state_) {
+          static_state_(other.static_state_),
+          parent_(other.parent_) {
     }
 
     container_with_static_bindings(self_type&& other)
         : runtime_registry_(std::move(other.runtime_registry_)),
           static_registry_(std::move(other.static_registry_)),
-          static_state_(std::move(other.static_state_)) {
+          static_state_(std::move(other.static_state_)),
+          parent_(other.parent_) {
     }
 
     self_type& operator=(const self_type& other) {
@@ -643,6 +738,7 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             runtime_registry_ = other.runtime_registry_;
             static_registry_ = other.static_registry_;
             static_state_ = other.static_state_;
+            parent_ = other.parent_;
         }
         return *this;
     }
@@ -652,6 +748,7 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             runtime_registry_ = std::move(other.runtime_registry_);
             static_registry_ = std::move(other.static_registry_);
             static_state_ = std::move(other.static_state_);
+            parent_ = other.parent_;
         }
         return *this;
     }
@@ -670,28 +767,83 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
         if constexpr (detail::is_typed_key_v<IdType>) {
             using key_type = typename std::decay_t<IdType>::type;
             if constexpr (collection_traits<R>::is_collection) {
-                if (select_static_collection<R, key_type>()) {
-                    return resolve_static<T, false, key_type>();
+                if constexpr (has_static_collection_v<R, key_type>) {
+                    if (select_static_collection<R, key_type>()) {
+                        return resolve_static<T, false, key_type>();
+                    }
+                }
+                if constexpr (has_parent_v) {
+                    if (parent_ && count_collection<R, key_type>() == 0) {
+                        return resolve_parent<T, false, key_type>();
+                    }
                 }
             } else {
                 if (select_static_resolve<T, key_type>()) {
                     return resolve_static<T, false, key_type>();
                 }
+                if constexpr (has_parent_v) {
+                    if constexpr (static_resolve_status_v<
+                                      T, false, key_type> ==
+                                  detail::binding_selection_status::not_found) {
+                        if (parent_ &&
+                            resolve_binding_status<T, false, key_type>() ==
+                                detail::binding_selection_status::not_found) {
+                            return resolve_parent<T, false, key_type>();
+                        }
+                    }
+                }
             }
             runtime_context context;
             return resolve<T, false, true, key_type>(context);
         } else if constexpr (!is_none_v<std::decay_t<IdType>>) {
+            if constexpr (has_parent_v) {
+                if constexpr (collection_traits<R>::is_collection) {
+                    if (parent_ &&
+                        runtime_registry_
+                                .template count_runtime_collection<R>(id) ==
+                            0) {
+                        return parent_->template resolve<T>(
+                            std::forward<IdType>(id));
+                    }
+                } else {
+                    if (parent_ &&
+                        runtime_registry_.template binding_status_for_id<T>(
+                            id) ==
+                            detail::binding_selection_status::not_found) {
+                        return parent_->template resolve<T>(
+                            std::forward<IdType>(id));
+                    }
+                }
+            }
             runtime_context context;
             return resolve_runtime_only<T, false, runtime_auto_constructible_v<T>>(
                 context, std::forward<IdType>(id));
         } else {
             if constexpr (collection_traits<R>::is_collection) {
-                if (select_static_collection<R>()) {
-                    return resolve_static<T, false>();
+                if constexpr (has_static_collection_v<R>) {
+                    if (select_static_collection<R>()) {
+                        return resolve_static<T, false>();
+                    }
+                }
+                if constexpr (has_parent_v) {
+                    if (parent_ && count_collection<R>() == 0) {
+                        return resolve_parent<T, false>();
+                    }
                 }
             } else {
                 if (select_static_resolve<T>()) {
                     return resolve_static<T, false>();
+                }
+                if constexpr (has_parent_v) {
+                    if constexpr (static_resolve_status_v<
+                                      T, false> ==
+                                  detail::binding_selection_status::not_found) {
+                        if (parent_ &&
+                            resolve_binding_status<T, false>() ==
+                                detail::binding_selection_status::not_found) {
+                            return resolve_parent<T, false>();
+                        }
+                    }
                 }
             }
             runtime_context context;
@@ -848,6 +1000,17 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
             detail::binding_resolution_policy::ambiguous_on_conflict);
     }
 
+    template <typename T, bool RemoveRvalueReferences, typename Key = void>
+    detail::binding_selection_status resolve_binding_status() {
+        using request_type = resolve_request_t<T, RemoveRvalueReferences>;
+        const auto runtime_status =
+            runtime_registry_.template binding_status<request_type, Key>();
+        return detail::resolve_binding_status<
+            static_resolve_status_v<T, RemoveRvalueReferences, Key>>(
+            runtime_status,
+            detail::binding_resolution_policy::ambiguous_on_conflict);
+    }
+
     template <typename T, typename Key = void, typename Fn>
     std::size_t append_collection(T& results, runtime_context& context,
                                   Fn&& fn) {
@@ -908,21 +1071,63 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     template <typename T, bool RemoveRvalueReferences, bool CheckCache = true,
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     R resolve(static_context_type& context, none_t) {
-        return resolve_static<T, RemoveRvalueReferences>(context);
+        if constexpr (has_static_resolve_request_v<T,
+                                                   RemoveRvalueReferences>) {
+            return resolve_static<T, RemoveRvalueReferences>(context);
+        } else if constexpr (has_parent_v) {
+            if constexpr (static_resolve_status_v<
+                              T, RemoveRvalueReferences> ==
+                          detail::binding_selection_status::not_found) {
+                if (parent_) {
+                    return resolve_parent<T, RemoveRvalueReferences>();
+                }
+            }
+            return resolve_static<T, RemoveRvalueReferences>(context);
+        } else {
+            return resolve_static<T, RemoveRvalueReferences>(context);
+        }
     }
 
     template <typename T, bool RemoveRvalueReferences, bool CheckCache = true,
               typename Key = void,
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     R resolve(static_context_type& context) {
-        return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        if constexpr (has_static_resolve_request_v<T, RemoveRvalueReferences,
+                                                   Key>) {
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        } else if constexpr (has_parent_v) {
+            if constexpr (static_resolve_status_v<
+                              T, RemoveRvalueReferences, Key> ==
+                          detail::binding_selection_status::not_found) {
+                if (parent_) {
+                    return resolve_parent<T, RemoveRvalueReferences, Key>();
+                }
+            }
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        } else {
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        }
     }
 
     template <typename T, bool RemoveRvalueReferences, bool CheckCache,
               typename Key,
               typename R = resolve_request_t<T, RemoveRvalueReferences>>
     R resolve(static_context_type& context, key<Key>) {
-        return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        if constexpr (has_static_resolve_request_v<T, RemoveRvalueReferences,
+                                                   Key>) {
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        } else if constexpr (has_parent_v) {
+            if constexpr (static_resolve_status_v<
+                              T, RemoveRvalueReferences, Key> ==
+                          detail::binding_selection_status::not_found) {
+                if (parent_) {
+                    return resolve_parent<T, RemoveRvalueReferences, Key>();
+                }
+            }
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        } else {
+            return resolve_static<T, RemoveRvalueReferences, Key>(context);
+        }
     }
 
     template <typename T, bool RemoveRvalueReferences, bool CheckCache = true,
@@ -936,10 +1141,29 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     R resolve(runtime_context& context) {
         if constexpr (collection_traits<R>::is_collection) {
+            if constexpr (has_parent_v) {
+                if (parent_ && count_collection<R, Key>() == 0) {
+                    return resolve_parent<T, RemoveRvalueReferences,
+                                          CheckCache, Key>(context);
+                }
+            }
             return construct_collection<R>(context,
                                            detail::binding_collection_append{},
                                            collection_key<Key>());
         } else {
+            if constexpr (has_parent_v) {
+                if constexpr (static_resolve_status_v<
+                                  T, RemoveRvalueReferences, Key> ==
+                              detail::binding_selection_status::not_found) {
+                    if (parent_ &&
+                        resolve_binding_status<T, RemoveRvalueReferences,
+                                               Key>() ==
+                            detail::binding_selection_status::not_found) {
+                        return resolve_parent<T, RemoveRvalueReferences,
+                                              CheckCache, Key>(context);
+                    }
+                }
+            }
             using request_type = R;
             detail::runtime_binding_source<self_type, T, RemoveRvalueReferences,
                                            Key, request_type>
@@ -972,6 +1196,7 @@ class detail::container_with_static_bindings<static_registry<Registrations...>>
     runtime_registry_type runtime_registry_;
     static_registry_type static_registry_;
     static_state static_state_;
+    parent_container_type* parent_ = nullptr;
 };
 
 namespace detail {
@@ -979,6 +1204,19 @@ namespace detail {
 template <typename... Params> struct container_base;
 template <typename Param, typename Enable = void>
 struct container_base_from_parameter;
+template <typename Param, typename Parent, typename Enable = void>
+struct container_base_from_static_parent;
+struct container_base_runtime_two_parameter_tag {};
+struct container_base_static_parent_tag {};
+struct container_base_invalid_two_parameter_tag {};
+
+template <typename First>
+using container_base_two_parameter_tag_t = std::conditional_t<
+    is_runtime_container_traits_v<First>, container_base_runtime_two_parameter_tag,
+    std::conditional_t<is_static_registry_v<First> ||
+                           is_bindings_wrapper_v<First>,
+                       container_base_static_parent_tag,
+                       container_base_invalid_two_parameter_tag>>;
 
 template <> struct container_base<> {
     using type = runtime_container<dynamic_container_traits>;
@@ -990,9 +1228,28 @@ template <typename Param> struct container_base<Param> {
 
 template <typename First, typename Second>
 struct container_base<First, Second> {
-    static_assert(is_runtime_container_traits_v<First>,
-                  "container<T, U> requires runtime traits + allocator");
+    using type = typename container_base<
+        container_base_two_parameter_tag_t<First>, First, Second>::type;
+};
+
+template <typename First, typename Second>
+struct container_base<container_base_runtime_two_parameter_tag, First,
+                      Second> {
     using type = runtime_container<First, Second, void>;
+};
+
+template <typename First, typename Second>
+struct container_base<container_base_static_parent_tag, First, Second> {
+    using type = typename container_base_from_static_parent<First, Second>::type;
+};
+
+template <typename First, typename Second>
+struct container_base<container_base_invalid_two_parameter_tag, First,
+                      Second> {
+    static_assert(
+        container_dependent_false_v<First, Second>,
+        "container<T, U> requires runtime traits + allocator or "
+        "compile-time bindings + parent container");
 };
 
 template <typename First, typename Second, typename Third>
@@ -1042,6 +1299,31 @@ struct container_base_from_parameter<
                   "bindings source");
 
     using type = container_with_static_bindings<static_registry_type>;
+};
+
+template <typename Param, typename Parent, typename Enable>
+struct container_base_from_static_parent {
+    static_assert(container_dependent_false_v<Param, Parent>,
+                  "container<bindings<...>, Parent> requires a valid "
+                  "compile-time bindings source");
+};
+
+template <typename Param, typename Parent>
+struct container_base_from_static_parent<
+    Param, Parent, std::enable_if_t<is_static_registry_v<Param>>> {
+    using type = container_with_static_bindings<Param, Parent>;
+};
+
+template <typename Param, typename Parent>
+struct container_base_from_static_parent<
+    Param, Parent, std::enable_if_t<is_bindings_wrapper_v<Param>>> {
+    using static_registry_type = bindings_wrapper_registry_t<Param>;
+
+    static_assert(is_static_registry_v<static_registry_type>,
+                  "container<bindings<...>, Parent> requires a valid "
+                  "compile-time bindings source");
+
+    using type = container_with_static_bindings<static_registry_type, Parent>;
 };
 
 } // namespace detail

--- a/include/dingo/runtime/registry.h
+++ b/include/dingo/runtime/registry.h
@@ -44,7 +44,8 @@
 namespace dingo {
 namespace detail {
 
-template <typename StaticRegistry> class container_with_static_bindings;
+template <typename StaticRegistry, typename ParentContainer>
+class container_with_static_bindings;
 
 } // namespace detail
 
@@ -53,7 +54,8 @@ template <typename ContainerTraits, typename Allocator, typename ParentRegistry,
 class runtime_registry : public allocator_base<Allocator> {
     friend class runtime_context;
     template <typename, typename> friend class detail::binding_resolution;
-    template <typename> friend class detail::container_with_static_bindings;
+    template <typename, typename>
+    friend class detail::container_with_static_bindings;
     template <typename, typename, bool, typename>
     friend struct detail::runtime_selected_binding_source;
     template <typename, typename, bool, bool, typename>

--- a/include/dingo/static/container_traits.h
+++ b/include/dingo/static/container_traits.h
@@ -32,11 +32,13 @@ template <typename Tag = void> struct static_container_traits {
     static constexpr bool cache_enabled = true;
 };
 
-template <typename StaticSource> class static_container;
+template <typename StaticSource, typename ParentContainer = void>
+class static_container;
 
 namespace detail {
 
-template <typename StaticRegistry> class container_with_static_bindings;
+template <typename StaticRegistry, typename ParentContainer = void>
+class container_with_static_bindings;
 
 template <typename T> struct is_static_registry : std::false_type {};
 

--- a/include/dingo/static_container.h
+++ b/include/dingo/static_container.h
@@ -28,17 +28,39 @@ namespace dingo {
 
 namespace detail {
 
-template <typename StaticRegistry> class static_container_impl;
+struct static_container_no_dependency_diagnostics {};
+
+template <typename StaticRegistry, bool HasParent>
+struct static_container_dependency_diagnostics_base;
 
 template <typename... Registrations>
-class static_container_impl<static_registry<Registrations...>>
-    : private static_registry_dependency_diagnostics<
+struct static_container_dependency_diagnostics_base<
+    static_registry<Registrations...>, false>
+    : static_registry_dependency_diagnostics<
           typename static_registry<Registrations...>::interface_bindings,
-          binding_model<Registrations>...> {
+          binding_model<Registrations>...> {};
+
+template <typename... Registrations>
+struct static_container_dependency_diagnostics_base<
+    static_registry<Registrations...>, true>
+    : static_container_no_dependency_diagnostics {};
+
+template <typename StaticRegistry, typename ParentContainer = void>
+class static_container_impl;
+
+template <typename ParentContainer, typename... Registrations>
+class static_container_impl<static_registry<Registrations...>, ParentContainer>
+    : private static_container_dependency_diagnostics_base<
+          static_registry<Registrations...>,
+          !std::is_void_v<ParentContainer>> {
     using registry_type_ = static_registry<Registrations...>;
-    using graph_type_ = typename static_container_graph_type<
-        registry_type_, registry_type_::dependencies_are_resolved>::type;
-    using self_type = static_container_impl<registry_type_>;
+    static constexpr bool has_parent_v = !std::is_void_v<ParentContainer>;
+    using graph_type_ = std::conditional_t<
+        has_parent_v, graph_analysis<registry_type_, true>,
+        typename static_container_graph_type<
+            registry_type_, registry_type_::dependencies_are_resolved>::type>;
+    using self_type = static_container_impl<registry_type_, ParentContainer>;
+    using parent_container_type = ParentContainer;
     using state_type = static_storage_state<Registrations...>;
     using scope_ref = static_binding_scope_ref<state_type, Registrations...>;
     using context_type = static_context<registry_type_>;
@@ -53,9 +75,16 @@ class static_container_impl<static_registry<Registrations...>>
         self_type& host;
 
         constexpr binding_selection_status status() const {
-            static_assert(selection::status !=
-                              binding_selection_status::not_found,
-                          "static_container cannot resolve an unbound type");
+            if constexpr (has_parent_v &&
+                          selection::status ==
+                              binding_selection_status::not_found) {
+                return selection::status;
+            } else {
+                static_assert(selection::status !=
+                                  binding_selection_status::not_found,
+                              "static_container cannot resolve an unbound "
+                              "type");
+            }
             static_assert(selection::status != binding_selection_status::ambiguous,
                           "static_container cannot resolve an ambiguously "
                           "bound type");
@@ -73,6 +102,50 @@ class static_container_impl<static_registry<Registrations...>>
     };
 
     scope_ref state_ref() { return scope_ref(static_state_); }
+
+    template <typename Request, typename Key>
+    using static_selection_t = static_binding_t<
+        typename registry_type_::template bindings<Request, Key>>;
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void>
+    static constexpr bool has_static_resolve_request_v =
+        static_selection_t<resolve_request_t<T, RemoveRvalueReferences>,
+                           Key>::status == binding_selection_status::found;
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void>
+    static constexpr binding_selection_status static_resolve_status_v =
+        static_selection_t<resolve_request_t<T, RemoveRvalueReferences>,
+                           Key>::status;
+
+    template <typename Collection, typename Key = void>
+    static constexpr std::size_t static_collection_count_v =
+        static_collection_binding_count<registry_type_, Collection, Key>();
+
+    template <typename Collection, typename Key = void,
+              typename R = Collection>
+    R resolve_missing_parent_collection() {
+        if (parent_) {
+            if constexpr (std::is_void_v<Key>) {
+                return parent_->template resolve<Collection>();
+            } else {
+                return parent_->template resolve<Collection>(key<Key>{});
+            }
+        }
+        using resolve_type =
+            typename collection_traits<Collection>::resolve_type;
+        throw make_collection_type_not_found_exception<Collection,
+                                                       resolve_type>();
+    }
+
+    template <typename T, bool RemoveRvalueReferences, typename Key = void,
+              typename R = resolve_result_t<T, RemoveRvalueReferences>>
+    R resolve_parent() {
+        if constexpr (std::is_void_v<Key>) {
+            return parent_->template resolve<T>();
+        } else {
+            return parent_->template resolve<T>(key<Key>{});
+        }
+    }
 
   public:
     using source_type = registry_type_;
@@ -98,6 +171,12 @@ class static_container_impl<static_registry<Registrations...>>
     static_source_type& registry() { return static_registry_; }
 
     const static_source_type& registry() const { return static_registry_; }
+
+    static_container_impl() = default;
+
+    template <typename Parent = ParentContainer,
+              std::enable_if_t<!std::is_void_v<Parent>, int> = 0>
+    explicit static_container_impl(Parent* parent) : parent_(parent) {}
 
     template <typename T, typename Key = void,
               typename R = request_result_t<T>>
@@ -129,8 +208,25 @@ class static_container_impl<static_registry<Registrations...>>
                 }
             }
         }
-        context_type context;
-        return resolve<T, false, Key>(context);
+        if constexpr (collection_traits<R>::is_collection) {
+            if constexpr (has_parent_v &&
+                          static_collection_count_v<R, Key> == 0) {
+                return resolve_missing_parent_collection<R, Key>();
+            } else {
+                context_type context;
+                return resolve<T, false, Key>(context);
+            }
+        } else {
+            if constexpr (has_parent_v &&
+                          static_resolve_status_v<T, false, Key> ==
+                              binding_selection_status::not_found) {
+                if (parent_) {
+                    return resolve_parent<T, false, Key>();
+                }
+            }
+            context_type context;
+            return resolve<T, false, Key>(context);
+        }
     }
 
     template <typename T, typename Factory = constructor<normalized_type_t<T>>,
@@ -247,13 +343,27 @@ class static_container_impl<static_registry<Registrations...>>
               typename R = resolve_result_t<T, RemoveRvalueReferences>>
     R resolve(context_type& context) {
         if constexpr (collection_traits<R>::is_collection) {
-            auto state = state_ref();
-            return state.template construct_static_collection<
-                R, Key, static_source_type>(*this, context);
+            if constexpr (has_parent_v &&
+                          static_collection_count_v<R, Key> == 0) {
+                return resolve_missing_parent_collection<R, Key>();
+            } else {
+                auto state = state_ref();
+                return state.template construct_static_collection<
+                    R, Key, static_source_type>(*this, context);
+            }
         } else {
             using lookup_request_type =
                 resolve_request_t<T, RemoveRvalueReferences>;
             using request_type = R;
+            if constexpr (has_parent_v) {
+                if constexpr (static_resolve_status_v<
+                                  T, RemoveRvalueReferences, Key> ==
+                              binding_selection_status::not_found) {
+                    if (parent_) {
+                        return resolve_parent<T, RemoveRvalueReferences, Key>();
+                    }
+                }
+            }
             diagnostic_static_binding_source<request_type, lookup_request_type,
                                              Key>
                 source{*this};
@@ -281,14 +391,21 @@ class static_container_impl<static_registry<Registrations...>>
   private:
     static_source_type static_registry_;
     state_type static_state_;
+    parent_container_type* parent_ = nullptr;
 };
 
 } // namespace detail
 
-template <typename StaticSource>
+template <typename StaticSource, typename ParentContainer>
 class static_container
     : public detail::static_container_impl<
-          static_bindings_source_t<StaticSource>> {};
+          static_bindings_source_t<StaticSource>, ParentContainer> {
+    using base_type = detail::static_container_impl<
+        static_bindings_source_t<StaticSource>, ParentContainer>;
+
+  public:
+    using base_type::base_type;
+};
 
 } // namespace dingo
 

--- a/include/dingo/storage/materialized_source.h
+++ b/include/dingo/storage/materialized_source.h
@@ -16,6 +16,11 @@
 #include <type_traits>
 #include <utility>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
+
 namespace dingo {
 namespace detail {
 template <typename Source> class rvalue_source {
@@ -227,3 +232,7 @@ pointer_source<Source> make_resolved_source(Source* source) {
 
 } // namespace detail
 } // namespace dingo
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/test/lit/check_codegen_probe_sizes.py
+++ b/test/lit/check_codegen_probe_sizes.py
@@ -113,7 +113,7 @@ PROBE_LIMITS = {
     },
     "probe_static_resolution_mixed_container_interface_handle": {
         "default": 0x200,
-        "clang": 0x250,
+        "clang": 0x260,
         "gcc_arm64": 0x360,
     },
     "probe_runtime_resolution_interface_handle": {

--- a/test/matrix/axis_containers.py
+++ b/test/matrix/axis_containers.py
@@ -43,12 +43,14 @@ CONTAINERS = (
         name="static_container",
         modes=frozenset({"static"}),
         container_type="dingo::static_container<static_bindings>",
+        provides=frozenset({"static_parent_static_child"}),
         support_headers=("matrix/support/static_containers.h",),
     ),
     container(
         name="container_static",
         modes=frozenset({"static"}),
         container_type="dingo::container<static_bindings>",
+        provides=frozenset({"static_parent_container_child"}),
         support_headers=("matrix/support/container_containers.h",),
     ),
     container(

--- a/test/matrix/axis_feature_cases.py
+++ b/test/matrix/axis_feature_cases.py
@@ -16,6 +16,46 @@ VALUE_DEPENDENCY = frozenset({"direct_value_resolution", "stable_concrete_storag
 
 FEATURE_CASES = (
     FeatureCaseSpec(
+        name="container_child_container_parent",
+        feature="static_parent_container",
+        requires=frozenset({"static_parent_container_child"}),
+        supported_exposed_types=frozenset({"concrete"}),
+        supported_resolved_types=frozenset({"value_ref_ptr"}),
+        checks=(
+            "exercise_static_parent_container_pair<container_parent_shape, container_child_shape>();",
+        ),
+    ),
+    FeatureCaseSpec(
+        name="container_child_static_parent",
+        feature="static_parent_container",
+        requires=frozenset({"static_parent_container_child"}),
+        supported_exposed_types=frozenset({"concrete"}),
+        supported_resolved_types=frozenset({"value_ref_ptr"}),
+        checks=(
+            "exercise_static_parent_container_pair<static_parent_shape, container_child_shape>();",
+        ),
+    ),
+    FeatureCaseSpec(
+        name="static_child_static_parent",
+        feature="static_parent_container",
+        requires=frozenset({"static_parent_static_child"}),
+        supported_exposed_types=frozenset({"concrete"}),
+        supported_resolved_types=frozenset({"value_ref_ptr"}),
+        checks=(
+            "exercise_static_parent_container_pair<static_parent_shape, static_child_shape>();",
+        ),
+    ),
+    FeatureCaseSpec(
+        name="static_child_container_parent",
+        feature="static_parent_container",
+        requires=frozenset({"static_parent_static_child"}),
+        supported_exposed_types=frozenset({"concrete"}),
+        supported_resolved_types=frozenset({"value_ref_ptr"}),
+        checks=(
+            "exercise_static_parent_container_pair<container_parent_shape, static_child_shape>();",
+        ),
+    ),
+    FeatureCaseSpec(
         name="inferred_lambda",
         feature="invoke",
         requires=VALUE_DEPENDENCY,

--- a/test/matrix/axis_features.py
+++ b/test/matrix/axis_features.py
@@ -172,6 +172,19 @@ FEATURES = (
         ),
     ),
     Feature(
+        name="static_parent_container",
+        requires=frozenset(
+            {
+                "concrete_binding",
+                "direct_value_resolution",
+                "resolved_concrete",
+                "stable_concrete_storage",
+            }
+        ),
+        modes=frozenset({"static"}),
+        support_headers=("matrix/support/static_parent_container.h",),
+    ),
+    Feature(
         name="annotated",
         requires=frozenset({"annotated_binding", "resolved_annotated"}),
         modes=frozenset({"runtime", "static", "mixed"}),

--- a/test/matrix/support/static_parent_container.h
+++ b/test/matrix/support/static_parent_container.h
@@ -1,0 +1,182 @@
+//
+// This file is part of dingo project <https://github.com/romanpauk/dingo>
+//
+// See LICENSE for license and copyright information
+// SPDX-License-Identifier: MIT
+//
+
+#pragma once
+
+#include <dingo/container.h>
+#include <dingo/static_container.h>
+#include <dingo/storage/shared.h>
+#include <dingo/storage/unique.h>
+
+#include <vector>
+
+namespace dingo::matrix {
+
+struct parent_config {
+    parent_config() : value(1) {}
+
+    int value;
+};
+
+struct child_service {
+    explicit child_service(parent_config& config) : value(config.value) {}
+
+    int value;
+};
+
+struct child_config : parent_config {
+    child_config() { value = 2; }
+};
+
+struct second_child_config : parent_config {
+    second_child_config() { value = 3; }
+};
+
+struct container_parent_shape {
+    template <typename Bindings>
+    using type = dingo::container<Bindings>;
+};
+
+struct static_parent_shape {
+    template <typename Bindings>
+    using type = dingo::static_container<Bindings>;
+};
+
+struct container_child_shape {
+    static constexpr bool reports_ambiguity_at_runtime = true;
+
+    template <typename Bindings, typename Parent>
+    using type = dingo::container<Bindings, Parent>;
+};
+
+struct static_child_shape {
+    static constexpr bool reports_ambiguity_at_runtime = false;
+
+    template <typename Bindings, typename Parent>
+    using type = dingo::static_container<Bindings, Parent>;
+};
+
+template <typename ParentShape, typename ChildShape>
+void assert_static_parent_dependency_fallback() {
+    using parent_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<parent_config>>>;
+    using child_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::unique>,
+                                    dingo::storage<child_service>>>;
+    using parent_type = typename ParentShape::template type<parent_bindings>;
+    using child_type =
+        typename ChildShape::template type<child_bindings, parent_type>;
+
+    parent_type parent;
+    child_type child(&parent);
+
+    ASSERT_EQ(child.template resolve<parent_config&>().value, 1);
+    ASSERT_EQ(child.template resolve<child_service>().value, 1);
+}
+
+template <typename ParentShape, typename ChildShape>
+void assert_static_parent_child_override() {
+    using parent_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<parent_config>>>;
+    using child_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<child_config>,
+                                    dingo::interfaces<parent_config>>,
+                        dingo::bind<dingo::scope<dingo::unique>,
+                                    dingo::storage<child_service>>>;
+    using parent_type = typename ParentShape::template type<parent_bindings>;
+    using child_type =
+        typename ChildShape::template type<child_bindings, parent_type>;
+
+    parent_type parent;
+    child_type child(&parent);
+
+    ASSERT_EQ(parent.template resolve<parent_config&>().value, 1);
+    ASSERT_EQ(child.template resolve<parent_config&>().value, 2);
+    ASSERT_EQ(child.template resolve<child_service>().value, 2);
+}
+
+template <typename ParentShape, typename ChildShape>
+void assert_static_parent_child_ambiguity() {
+    using parent_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<parent_config>>>;
+    using child_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<child_config>,
+                                    dingo::interfaces<parent_config>>,
+                        dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<second_child_config>,
+                                    dingo::interfaces<parent_config>>>;
+    using parent_type = typename ParentShape::template type<parent_bindings>;
+    using child_type =
+        typename ChildShape::template type<child_bindings, parent_type>;
+
+    parent_type parent;
+    child_type child(&parent);
+
+    ASSERT_THROW(child.template resolve<parent_config&>(),
+                 dingo::type_ambiguous_exception);
+}
+
+template <typename ParentShape, typename ChildShape>
+void assert_static_parent_collection_fallback() {
+    using parent_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<parent_config>>>;
+    using child_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::unique>,
+                                    dingo::storage<child_service>>>;
+    using parent_type = typename ParentShape::template type<parent_bindings>;
+    using child_type =
+        typename ChildShape::template type<child_bindings, parent_type>;
+
+    parent_type parent;
+    child_type child(&parent);
+
+    auto values = child.template resolve<std::vector<parent_config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    ASSERT_EQ(values[0]->value, 1);
+}
+
+template <typename ParentShape, typename ChildShape>
+void assert_static_parent_collection_override() {
+    using parent_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<parent_config>>>;
+    using child_bindings =
+        dingo::bindings<dingo::bind<dingo::scope<dingo::shared>,
+                                    dingo::storage<child_config>,
+                                    dingo::interfaces<parent_config>>>;
+    using parent_type = typename ParentShape::template type<parent_bindings>;
+    using child_type =
+        typename ChildShape::template type<child_bindings, parent_type>;
+
+    parent_type parent;
+    child_type child(&parent);
+
+    auto values = child.template resolve<std::vector<parent_config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    ASSERT_EQ(values[0]->value, 2);
+}
+
+template <typename ParentShape, typename ChildShape>
+void exercise_static_parent_container_pair() {
+    assert_static_parent_dependency_fallback<ParentShape, ChildShape>();
+    assert_static_parent_child_override<ParentShape, ChildShape>();
+    if constexpr (ChildShape::reports_ambiguity_at_runtime) {
+        assert_static_parent_child_ambiguity<ParentShape, ChildShape>();
+    }
+    assert_static_parent_collection_fallback<ParentShape, ChildShape>();
+    assert_static_parent_collection_override<ParentShape, ChildShape>();
+}
+
+} // namespace dingo::matrix

--- a/test/registration/static_parent_container.cpp
+++ b/test/registration/static_parent_container.cpp
@@ -1,0 +1,196 @@
+//
+// This file is part of dingo project <https://github.com/romanpauk/dingo>
+//
+// See LICENSE for license and copyright information
+// SPDX-License-Identifier: MIT
+//
+
+#include <dingo/container.h>
+#include <dingo/static_container.h>
+#include <dingo/storage/shared.h>
+#include <dingo/storage/unique.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace dingo;
+
+namespace {
+struct config {
+    config() : value(1) {}
+
+    int value;
+};
+
+struct service {
+    explicit service(config& cfg) : value(cfg.value) {}
+
+    int value;
+};
+
+struct child_config : config {
+    child_config() { value = 2; }
+};
+
+struct second_child_config : config {
+    second_child_config() { value = 3; }
+};
+} // namespace
+
+TEST(static_parent_container_test,
+     child_static_binding_resolves_dependency_from_parent_static_graph) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<unique>, storage<service>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_EQ(child.resolve<config&>().value, 1);
+    EXPECT_EQ(child.resolve<service>().value, 1);
+}
+
+TEST(static_parent_container_test, child_static_binding_overrides_parent) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>,
+                 dingo::bind<scope<unique>, storage<service>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_EQ(parent.resolve<config&>().value, 1);
+    EXPECT_EQ(child.resolve<config&>().value, 2);
+    EXPECT_EQ(child.resolve<service>().value, 2);
+}
+
+TEST(static_parent_container_test, child_ambiguity_does_not_fall_back_to_parent) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>,
+                 dingo::bind<scope<shared>, storage<second_child_config>,
+                             interfaces<config>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_THROW(child.resolve<config&>(), type_ambiguous_exception);
+}
+
+TEST(static_parent_container_test,
+     child_dependency_ambiguity_does_not_fall_back_to_parent) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>,
+                 dingo::bind<scope<shared>, storage<second_child_config>,
+                             interfaces<config>>,
+                 dingo::bind<scope<unique>, storage<service>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_THROW(child.resolve<service>(), type_ambiguous_exception);
+}
+
+TEST(static_parent_container_test,
+     child_collection_falls_back_to_parent_when_local_collection_is_empty) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<unique>, storage<service>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    auto values = child.resolve<std::vector<config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    EXPECT_EQ(values[0]->value, 1);
+}
+
+TEST(static_parent_container_test, child_collection_overrides_parent_collection) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>>;
+
+    container<parent_bindings> parent;
+    container<child_bindings, decltype(parent)> child(&parent);
+
+    auto values = child.resolve<std::vector<config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    EXPECT_EQ(values[0]->value, 2);
+}
+
+TEST(static_parent_container_test,
+     static_child_resolves_dependency_from_parent_static_graph) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<unique>, storage<service>>>;
+
+    static_container<parent_bindings> parent;
+    static_container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_EQ(child.resolve<config&>().value, 1);
+    EXPECT_EQ(child.resolve<service>().value, 1);
+}
+
+TEST(static_parent_container_test, static_child_binding_overrides_parent) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>,
+                 dingo::bind<scope<unique>, storage<service>>>;
+
+    static_container<parent_bindings> parent;
+    static_container<child_bindings, decltype(parent)> child(&parent);
+
+    EXPECT_EQ(parent.resolve<config&>().value, 1);
+    EXPECT_EQ(child.resolve<config&>().value, 2);
+    EXPECT_EQ(child.resolve<service>().value, 2);
+}
+
+TEST(static_parent_container_test,
+     static_child_collection_falls_back_to_parent_when_local_collection_is_empty) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<unique>, storage<service>>>;
+
+    static_container<parent_bindings> parent;
+    static_container<child_bindings, decltype(parent)> child(&parent);
+
+    auto values = child.resolve<std::vector<config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    EXPECT_EQ(values[0]->value, 1);
+}
+
+TEST(static_parent_container_test,
+     static_child_collection_overrides_parent_collection) {
+    using parent_bindings =
+        bindings<dingo::bind<scope<shared>, storage<config>>>;
+    using child_bindings =
+        bindings<dingo::bind<scope<shared>, storage<child_config>,
+                             interfaces<config>>>;
+
+    static_container<parent_bindings> parent;
+    static_container<child_bindings, decltype(parent)> child(&parent);
+
+    auto values = child.resolve<std::vector<config*>>();
+
+    ASSERT_EQ(values.size(), 1u);
+    EXPECT_EQ(values[0]->value, 2);
+}


### PR DESCRIPTION
## Summary
- support parent fallback for container<bindings, Parent> and static_container<bindings, Parent>
- preserve child-first semantics so ambiguity does not fall back to the parent
- add unit and generated matrix coverage for mixed/static parent-child shape pairs

## Tests
- git diff --check
- ./build/dingo_unit_test --gtest_filter=static_parent_container_test.*
- ./build/dingo_matrix_test_static_parent_container
- ./build/dingo_unit_test
- ctest --test-dir build -L runtime --output-on-failure

## Notes
- keyed parent fallback matrix cases are not added in this change