### PR TITLE
Support static shared-cyclical binding graphs

### DIFF
--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -219,7 +219,7 @@ Runtime registration makes sense when:
 Compile-time bindings make sense when:
 
 - the participating types are known and stable at compile time
-- missing dependencies and cycles should fail during compilation
+- missing dependencies and unsupported cycles should fail during compilation
 - lookup should avoid mutable runtime registration state
 
 See:
@@ -338,8 +338,9 @@ Some resolution details are easy to miss:
 - runtime registration errors surface as exceptions during resolution, while
   compile-time bindings can diagnose declared graph errors during compilation
 - shared resolutions can act as a cache for already-built objects
-- `shared_cyclical` supports cycles through two-phase construction and should be
-  treated as a constrained escape hatch rather than the default model
+- `shared_cyclical` supports runtime and static cycles through two-phase
+  construction and should be treated as a constrained escape hatch rather than
+  the default model
 
 For a first pass through the project, read [Getting Started](getting-started.md)
 and [Core Concepts](core-concepts.md) first.

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -101,10 +101,14 @@ to the normal constructor-based path.
 
 ## Cycle Rules
 
-Purely static cycles are rejected at compile time.
+Purely static cycles are rejected at compile time unless every binding in the
+cycle uses `scope<shared_cyclical>`. A supported static cycle uses the same
+two-phase storage model as runtime `shared_cyclical` registration, so each
+participating slot can be published before its dependencies finish resolving.
 
-`container<bindings<...>>` also rejects statically known static cycles at
-compile time.
+`container<bindings<...>>` applies the same rule to statically known static
+cycles: ordinary static cycles are rejected, while all-`shared_cyclical` static
+cycles can resolve through the static binding path.
 
 Mixed runtime/static recursion that only becomes visible during actual runtime
 resolution is rejected at runtime through the normal recursion exception path.

--- a/docs/architecture/registration-and-resolution.md
+++ b/docs/architecture/registration-and-resolution.md
@@ -164,10 +164,11 @@ not try to model the full C++ overload-resolution space, which is why ambiguous,
 policy-sensitive, or readability-critical cases should move to an explicit
 factory.
 
-`container<bindings<...>>` also applies compile-time cycle rejection to
-statically known static cycles, while mixed runtime/static recursion that only
-appears during actual construction is still rejected at runtime by the recursion
-guard.
+`container<bindings<...>>` also checks statically known static cycles at compile
+time. Ordinary static cycles are rejected; cycles where every participating
+binding uses `scope<shared_cyclical>` are allowed through the static binding
+path. Mixed runtime/static recursion that only appears during actual
+construction is still rejected at runtime by the recursion guard.
 
 ## Good Source Companions
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -36,7 +36,8 @@ container<static_bindings> compile_time_container;
 
 Runtime registration is mutable container configuration. Compile-time bindings
 are part of the container type and can include `dependencies<...>` for static
-graph checks before the program runs.
+graph checks before the program runs. Static cycles are rejected unless every
+binding in the cycle uses `scope<shared_cyclical>`.
 
 <!-- { include("../examples/registration/non_intrusive.cpp", scope="////") -->
 
@@ -701,8 +702,8 @@ See:
 Dingo supports both runtime registrations and compile-time bindings. Runtime
 registration keeps cross-module usage practical, but wiring errors on that path
 surface as exceptions during resolution. Compile-time bindings move the declared
-graph into the type system, so missing static dependencies and static cycles can
-be diagnosed at compile time.
+graph into the type system, so missing static dependencies and unsupported
+static cycles can be diagnosed at compile time.
 
 When user code throws during resolution, the container remains in a valid state.
 Already completed shared resolutions may stay cached, because resolution is a

--- a/include/dingo/container.h
+++ b/include/dingo/container.h
@@ -694,8 +694,8 @@ class detail::container_with_static_bindings<static_registry<Registrations...>,
 
     static_assert(static_source_type::valid,
                   "container requires a valid compile-time bindings source");
-    static_assert(detail::graph_analysis<static_source_type, true>::acyclic,
-                  "container requires an acyclic compile-time binding graph");
+    static_assert(detail::graph_analysis<static_source_type, true>::resolvable,
+                  "container requires a resolvable compile-time binding graph");
     static_assert(
         (detail::binding_factory_is_default_constructible<
              detail::binding_model<Registrations>>::value &&

--- a/include/dingo/static/graph.h
+++ b/include/dingo/static/graph.h
@@ -97,13 +97,55 @@ template <typename Binding, typename StaticRegistry,
           bool InVisiting = type_list_contains_v<Binding, Visiting>>
 struct static_binding_resolvable;
 
+template <typename Binding>
+struct static_binding_uses_cyclical_storage
+    : std::is_same<typename Binding::binding_model_type::storage_tag,
+                   shared_cyclical> {};
+
+template <typename Binding>
+inline constexpr bool static_binding_uses_cyclical_storage_v =
+    static_binding_uses_cyclical_storage<Binding>::value;
+
+template <typename Binding, typename Visiting> struct static_cycle_path;
+
+template <typename Binding> struct static_cycle_path<Binding, type_list<>> {
+    using type = type_list<>;
+};
+
+template <typename Binding, typename Head, typename... Tail>
+struct static_cycle_path<Binding, type_list<Head, Tail...>> {
+    using tail_path =
+        typename static_cycle_path<Binding, type_list<Tail...>>::type;
+    using type = std::conditional_t<std::is_same_v<Binding, Head>,
+                                    type_list<Head, Tail...>, tail_path>;
+};
+
+template <typename Binding, typename Visiting>
+using static_cycle_path_t = typename static_cycle_path<Binding, Visiting>::type;
+
+template <typename Bindings> struct static_bindings_use_cyclical_storage;
+
+template <>
+struct static_bindings_use_cyclical_storage<type_list<>> : std::true_type {};
+
+template <typename... Bindings>
+struct static_bindings_use_cyclical_storage<type_list<Bindings...>>
+    : std::bool_constant<(static_binding_uses_cyclical_storage_v<Bindings> &&
+                          ...)> {};
+
+template <typename Binding, typename Visiting>
+inline constexpr bool static_cycle_uses_cyclical_storage_v =
+    static_bindings_use_cyclical_storage<
+        static_cycle_path_t<Binding, Visiting>>::value;
+
 template <typename StaticRegistry, typename Visiting>
 struct static_binding_resolvable<void, StaticRegistry, Visiting, false>
     : std::false_type {};
 
 template <typename Binding, typename StaticRegistry, typename Visiting>
 struct static_binding_resolvable<Binding, StaticRegistry, Visiting, true>
-    : std::false_type {};
+    : std::bool_constant<
+          static_cycle_uses_cyclical_storage_v<Binding, Visiting>> {};
 
 template <typename Binding, typename StaticRegistry, typename Visiting>
 struct static_binding_resolvable<Binding, StaticRegistry, Visiting, false>
@@ -726,6 +768,54 @@ template <typename Binding, typename StaticRegistry,
           bool RuntimeDependencies = false>
 struct static_binding_graph_temporary_slots;
 
+template <typename Bindings> struct static_graph_total_preserved_closure_depth;
+
+template <typename Bindings> struct static_graph_total_destructible_slots;
+
+template <typename Bindings> struct static_graph_total_temporary_slots;
+
+template <typename StaticRegistry, bool RuntimeDependencies, bool Acyclic,
+          bool ContainsCycle>
+struct static_graph_preserved_closure_depth_bound;
+
+template <typename StaticRegistry, bool RuntimeDependencies, bool Acyclic,
+          bool ContainsCycle>
+struct static_graph_destructible_slots_bound;
+
+template <typename StaticRegistry, bool RuntimeDependencies, bool Acyclic,
+          bool ContainsCycle>
+struct static_graph_temporary_slots_bound;
+
+template <>
+struct static_graph_total_preserved_closure_depth<type_list<>>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename... Bindings>
+struct static_graph_total_preserved_closure_depth<type_list<Bindings...>>
+    : std::integral_constant<
+          std::size_t, (static_binding_preserved_closure_cost_v<Bindings> +
+                        ... + std::size_t{0})> {};
+
+template <>
+struct static_graph_total_destructible_slots<type_list<>>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename... Bindings>
+struct static_graph_total_destructible_slots<type_list<Bindings...>>
+    : std::integral_constant<
+          std::size_t, (static_binding_destructible_slot_cost_v<Bindings> +
+                        ... + std::size_t{0})> {};
+
+template <>
+struct static_graph_total_temporary_slots<type_list<>>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename... Bindings>
+struct static_graph_total_temporary_slots<type_list<Bindings...>>
+    : std::integral_constant<std::size_t,
+                             (static_binding_temporary_slot_cost_v<Bindings> +
+                              ... + std::size_t{0})> {};
+
 template <typename StaticRegistry, bool RuntimeDependencies>
 struct static_graph_max_preserved_closure_depth_all<type_list<>, StaticRegistry,
                                                     RuntimeDependencies>
@@ -915,9 +1005,63 @@ struct static_graph_max_temporary_slots<StaticRegistry, RuntimeDependencies,
           typename StaticRegistry::interface_bindings, StaticRegistry,
           RuntimeDependencies> {};
 
-template <bool Acyclic, typename Visited, typename Order>
+template <typename StaticRegistry, bool RuntimeDependencies, bool ContainsCycle>
+struct static_graph_preserved_closure_depth_bound<
+    StaticRegistry, RuntimeDependencies, false, ContainsCycle>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_preserved_closure_depth_bound<
+    StaticRegistry, RuntimeDependencies, true, false>
+    : static_graph_max_preserved_closure_depth<StaticRegistry,
+                                               RuntimeDependencies, true> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_preserved_closure_depth_bound<
+    StaticRegistry, RuntimeDependencies, true, true>
+    : static_graph_total_preserved_closure_depth<
+          typename StaticRegistry::interface_bindings> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies, bool ContainsCycle>
+struct static_graph_destructible_slots_bound<
+    StaticRegistry, RuntimeDependencies, false, ContainsCycle>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_destructible_slots_bound<StaticRegistry,
+                                             RuntimeDependencies, true, false>
+    : static_graph_max_destructible_slots<StaticRegistry, RuntimeDependencies,
+                                          true> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_destructible_slots_bound<StaticRegistry,
+                                             RuntimeDependencies, true, true>
+    : static_graph_total_destructible_slots<
+          typename StaticRegistry::interface_bindings> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies, bool ContainsCycle>
+struct static_graph_temporary_slots_bound<StaticRegistry, RuntimeDependencies,
+                                          false, ContainsCycle>
+    : std::integral_constant<std::size_t, 0> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_temporary_slots_bound<StaticRegistry, RuntimeDependencies,
+                                          true, false>
+    : static_graph_max_temporary_slots<StaticRegistry, RuntimeDependencies,
+                                       true> {};
+
+template <typename StaticRegistry, bool RuntimeDependencies>
+struct static_graph_temporary_slots_bound<StaticRegistry, RuntimeDependencies,
+                                          true, true>
+    : static_graph_total_temporary_slots<
+          typename StaticRegistry::interface_bindings> {};
+
+template <bool Resolvable, typename Visited, typename Order,
+          bool ContainsCycle = false>
 struct graph_visit_result {
-    static constexpr bool acyclic = Acyclic;
+    static constexpr bool resolvable = Resolvable;
+    static constexpr bool contains_cycle = ContainsCycle;
+    static constexpr bool acyclic = Resolvable && !ContainsCycle;
     using visited = Visited;
     using order = Order;
 };
@@ -927,15 +1071,17 @@ struct graph_visit_merge;
 
 template <typename HeadResult, typename TailResult>
 struct graph_visit_merge<HeadResult, TailResult, true> {
-    using type =
-        graph_visit_result<true, typename TailResult::visited,
-                           type_list_cat_t<typename HeadResult::order,
-                                           typename TailResult::order>>;
+    using type = graph_visit_result<
+        true, typename TailResult::visited,
+        type_list_cat_t<typename HeadResult::order, typename TailResult::order>,
+        HeadResult::contains_cycle || TailResult::contains_cycle>;
 };
 
 template <typename HeadResult, typename TailResult>
 struct graph_visit_merge<HeadResult, TailResult, false> {
-    using type = graph_visit_result<false, typename TailResult::visited, void>;
+    using type = graph_visit_result<false, typename TailResult::visited, void,
+                                    HeadResult::contains_cycle ||
+                                        TailResult::contains_cycle>;
 };
 
 template <typename RecurseResult, typename Binding, bool Acyclic>
@@ -946,13 +1092,14 @@ struct graph_visit_append<RecurseResult, Binding, true> {
     using type = graph_visit_result<
         true,
         type_list_cat_t<typename RecurseResult::visited, type_list<Binding>>,
-        type_list_cat_t<typename RecurseResult::order, type_list<Binding>>>;
+        type_list_cat_t<typename RecurseResult::order, type_list<Binding>>,
+        RecurseResult::contains_cycle>;
 };
 
 template <typename RecurseResult, typename Binding>
 struct graph_visit_append<RecurseResult, Binding, false> {
-    using type =
-        graph_visit_result<false, typename RecurseResult::visited, void>;
+    using type = graph_visit_result<false, typename RecurseResult::visited,
+                                    void, RecurseResult::contains_cycle>;
 };
 
 template <typename Bindings, typename StaticRegistry, typename Visiting,
@@ -987,7 +1134,7 @@ struct graph_visit_all<type_list<Head, Tail...>, StaticRegistry, Visiting,
                                  RuntimeDependencies>::type;
 
     using tail_result = std::conditional_t<
-        head_result::acyclic,
+        head_result::resolvable,
         typename graph_visit_all<type_list<Tail...>, StaticRegistry, Visiting,
                                  typename head_result::visited,
                                  RuntimeDependencies>::type,
@@ -995,8 +1142,8 @@ struct graph_visit_all<type_list<Head, Tail...>, StaticRegistry, Visiting,
 
   public:
     using type = typename graph_visit_merge<head_result, tail_result,
-                                            head_result::acyclic &&
-                                                tail_result::acyclic>::type;
+                                            head_result::resolvable &&
+                                                tail_result::resolvable>::type;
 };
 
 template <typename Binding, typename StaticRegistry, typename Visiting,
@@ -1008,7 +1155,10 @@ template <typename Binding, typename StaticRegistry, typename Visiting,
           typename Visited, bool RuntimeDependencies>
 struct graph_visit_one_impl<Binding, StaticRegistry, Visiting, Visited,
                             RuntimeDependencies, true, false> {
-    using type = graph_visit_result<false, Visited, void>;
+    using type = std::conditional_t<
+        static_cycle_uses_cyclical_storage_v<Binding, Visiting>,
+        graph_visit_result<true, Visited, type_list<>, true>,
+        graph_visit_result<false, Visited, void>>;
 };
 
 template <typename Binding, typename StaticRegistry, typename Visiting,
@@ -1034,7 +1184,7 @@ struct graph_visit_one_impl<Binding, StaticRegistry, Visiting, Visited,
 
   public:
     using type = typename graph_visit_append<recurse_result, Binding,
-                                             recurse_result::acyclic>::type;
+                                             recurse_result::resolvable>::type;
 };
 
 template <typename Binding, typename StaticRegistry, typename Visiting,
@@ -1062,6 +1212,8 @@ struct basic_static_graph_topology_analysis {
                                  RuntimeDependencies>::type;
 
   public:
+    static constexpr bool resolvable = traversal::resolvable;
+    static constexpr bool contains_cycle = traversal::contains_cycle;
     static constexpr bool acyclic = traversal::acyclic;
     using topological_bindings =
         std::conditional_t<acyclic, typename traversal::order, void>;
@@ -1074,20 +1226,24 @@ struct basic_static_execution_traits {
                                                           RuntimeDependencies>;
 
   public:
+    static constexpr bool resolvable = topology::resolvable;
+    static constexpr bool contains_cycle = topology::contains_cycle;
     static constexpr bool acyclic = topology::acyclic;
     static constexpr std::size_t max_preserved_closure_depth =
-        static_graph_max_preserved_closure_depth<
-            StaticRegistry, RuntimeDependencies, acyclic>::value;
+        static_graph_preserved_closure_depth_bound<
+            StaticRegistry, RuntimeDependencies, resolvable,
+            contains_cycle>::value;
     static constexpr std::size_t max_destructible_slots =
-        static_graph_max_destructible_slots<StaticRegistry, RuntimeDependencies,
-                                            acyclic>::value;
+        static_graph_destructible_slots_bound<StaticRegistry,
+                                              RuntimeDependencies, resolvable,
+                                              contains_cycle>::value;
     static constexpr std::size_t max_temporary_slots =
-        static_graph_max_temporary_slots<StaticRegistry, RuntimeDependencies,
-                                         acyclic>::value;
+        static_graph_temporary_slots_bound<StaticRegistry, RuntimeDependencies,
+                                           resolvable, contains_cycle>::value;
     static constexpr std::size_t max_temporary_size =
-        static_graph_max_temporary_size<StaticRegistry, acyclic>::value;
+        static_graph_max_temporary_size<StaticRegistry, resolvable>::value;
     static constexpr std::size_t max_temporary_align =
-        static_graph_max_temporary_align<StaticRegistry, acyclic>::value;
+        static_graph_max_temporary_align<StaticRegistry, resolvable>::value;
 };
 
 template <typename StaticRegistry, bool RuntimeDependencies = false>
@@ -1125,6 +1281,10 @@ struct static_graph<static_registry<Registrations...>, void>
     static_assert(static_registry_type::valid,
                   "static_graph requires a valid compile-time bindings source");
 
+    static constexpr bool resolvable =
+        detail::graph_analysis<static_registry_type>::resolvable;
+    static constexpr bool contains_cycle =
+        detail::graph_analysis<static_registry_type>::contains_cycle;
     static constexpr bool acyclic =
         detail::graph_analysis<static_registry_type>::acyclic;
     using topological_bindings = typename detail::graph_analysis<

--- a/include/dingo/static/local_resolution.h
+++ b/include/dingo/static/local_resolution.h
@@ -113,8 +113,8 @@ class binding_resolution<Host, static_registry<Registrations...>>
     static_assert(static_registry_type::valid,
                   "register_type bindings<...> requires a valid compile-time "
                   "bindings source");
-    static_assert(detail::graph_analysis<static_registry_type, true>::acyclic,
-                  "register_type bindings<...> requires an acyclic "
+    static_assert(detail::graph_analysis<static_registry_type, true>::resolvable,
+                  "register_type bindings<...> requires a resolvable "
                   "compile-time binding graph");
     static_assert((detail::binding_factory_is_default_constructible<
                        detail::binding_model<Registrations>>::value &&

--- a/include/dingo/static/resolution.h
+++ b/include/dingo/static/resolution.h
@@ -29,6 +29,7 @@ struct static_container_graph_type<StaticRegistry, true> {
 template <typename StaticRegistry>
 struct static_container_graph_type<StaticRegistry, false> {
     struct type {
+        static constexpr bool resolvable = true;
         static constexpr bool acyclic = true;
     };
 };

--- a/include/dingo/static_container.h
+++ b/include/dingo/static_container.h
@@ -155,8 +155,8 @@ class static_container_impl<static_registry<Registrations...>, ParentContainer>
     static_assert(static_source_type::valid,
                   "static_container requires a valid compile-time bindings "
                   "source");
-    static_assert(graph_type_::acyclic,
-                  "static_container requires an acyclic compile-time binding "
+    static_assert(graph_type_::resolvable,
+                  "static_container requires a resolvable compile-time binding "
                   "graph");
     static_assert((binding_factory_is_default_constructible<
                        binding_model<Registrations>>::value &&

--- a/test/lit/container-local-bindings-cycle-is-rejected.cpp
+++ b/test/lit/container-local-bindings-cycle-is-rejected.cpp
@@ -24,4 +24,4 @@ int main() {
                         dingo::dependencies<a&>>>>();
 }
 
-// CHECK: register_type bindings<...> requires an acyclic compile-time binding graph
+// CHECK: register_type bindings<...> requires a resolvable compile-time binding graph

--- a/test/lit/container-static-bindings-cycle-is-rejected.cpp
+++ b/test/lit/container-static-bindings-cycle-is-rejected.cpp
@@ -18,4 +18,4 @@ int main() {
     (void)instance;
 }
 
-// CHECK: container requires an acyclic compile-time binding graph
+// CHECK: container requires a resolvable compile-time binding graph

--- a/test/lit/static-bindings-missing-inferred-dependency-is-rejected.cpp
+++ b/test/lit/static-bindings-missing-inferred-dependency-is-rejected.cpp
@@ -17,4 +17,4 @@ int main() {
     (void)instance;
 }
 
-// CHECK: {{(bindings<...> source requires every inferred constructor dependency to map to an interface binding|static_container requires an acyclic compile-time binding graph)}}
+// CHECK: {{(bindings<...> source requires every inferred constructor dependency to map to an interface binding|static_container requires a resolvable compile-time binding graph)}}

--- a/test/lit/static-container-cycle-is-rejected.cpp
+++ b/test/lit/static-container-cycle-is-rejected.cpp
@@ -17,4 +17,4 @@ int main() {
     (void)instance;
 }
 
-// CHECK: static_container requires an acyclic compile-time binding graph
+// CHECK: static_container requires a resolvable compile-time binding graph

--- a/test/matrix/axis_stored_types.py
+++ b/test/matrix/axis_stored_types.py
@@ -493,7 +493,6 @@ STORED_TYPES = (
         storage="dingo::storage<cycle_a_type>",
         supported_scopes=frozenset({"shared_cyclical"}),
         provides=frozenset({"stored_value", "cycle_graph"}),
-        supported_modes=frozenset({"runtime"}),
         support_headers=VALUE_HEADERS,
     ),
     StoredType(

--- a/test/registration/binding_graph.cpp
+++ b/test/registration/binding_graph.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-#include <dingo/static/graph.h>
 #include <dingo/static/activation_set.h>
+#include <dingo/static/graph.h>
 #include <dingo/storage/shared.h>
 #include <dingo/storage/shared_cyclical.h>
 #include <dingo/storage/unique.h>
@@ -61,18 +61,20 @@ TEST(static_graph_test, exposes_dependency_nodes_and_topological_order) {
 
     using config_binding = dingo::bind<scope<shared>, storage<config>>;
     using service_binding =
-        dingo::bind<scope<shared>, storage<service>, interfaces<service_interface>,
-             dependencies<config&>>;
-    using controller_binding =
-        dingo::bind<scope<unique>, storage<controller>,
-             dependencies<service_interface&>>;
-    using source = dingo::bindings<config_binding, service_binding, controller_binding>;
+        dingo::bind<scope<shared>, storage<service>,
+                    interfaces<service_interface>, dependencies<config&>>;
+    using controller_binding = dingo::bind<scope<unique>, storage<controller>,
+                                           dependencies<service_interface&>>;
+    using source =
+        dingo::bindings<config_binding, service_binding, controller_binding>;
     using graph = static_graph<source>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
+    static_assert(graph::resolvable);
     static_assert(graph::acyclic);
-    static_assert(std::is_same_v<typename graph::dependency_nodes<config>,
-                                 type_list<>>);
+    static_assert(
+        std::is_same_v<typename graph::dependency_nodes<config>, type_list<>>);
     static_assert(
         std::is_same_v<typename graph::dependency_nodes<service_interface>,
                        type_list<typename graph::node<config>>>);
@@ -84,30 +86,74 @@ TEST(static_graph_test, exposes_dependency_nodes_and_topological_order) {
                   type_list<typename graph::template binding<config>,
                             typename graph::template binding<service_interface>,
                             typename graph::template binding<controller>>>);
-    static_assert(std::is_same_v<
-                  typename graph::topological_nodes,
-                  type_list<typename graph::node<config>,
-                            typename graph::node<service_interface>,
-                            typename graph::node<controller>>>);
+    static_assert(
+        std::is_same_v<typename graph::topological_nodes,
+                       type_list<typename graph::node<config>,
+                                 typename graph::node<service_interface>,
+                                 typename graph::node<controller>>>);
     static_assert(static_traits::max_preserved_closure_depth == 2);
     static_assert(static_traits::max_destructible_slots == 0);
 }
 
-TEST(static_graph_test, detects_cycles_without_invalidating_compile_time_bindings_source) {
+TEST(static_graph_test,
+     detects_cycles_without_invalidating_compile_time_bindings_source) {
     struct a {};
     struct b {};
 
-    using a_binding =
-        dingo::bind<scope<shared>, storage<a>, dependencies<b&>>;
-    using b_binding =
-        dingo::bind<scope<shared>, storage<b>, dependencies<a&>>;
+    using a_binding = dingo::bind<scope<shared>, storage<a>, dependencies<b&>>;
+    using b_binding = dingo::bind<scope<shared>, storage<b>, dependencies<a&>>;
     using source = dingo::bindings<a_binding, b_binding>;
     using graph = static_graph<source>;
 
     static_assert(source::type::valid);
+    static_assert(!graph::resolvable);
     static_assert(!graph::acyclic);
     static_assert(std::is_same_v<typename graph::topological_bindings, void>);
     static_assert(std::is_same_v<typename graph::topological_nodes, void>);
+}
+
+TEST(static_graph_test,
+     allows_cycles_when_every_cycle_binding_is_shared_cyclical) {
+    struct a {};
+    struct b {};
+    struct owner {};
+
+    using a_binding =
+        dingo::bind<scope<shared_cyclical>, storage<a>, dependencies<b&>>;
+    using b_binding =
+        dingo::bind<scope<shared_cyclical>, storage<b>, dependencies<a&>>;
+    using owner_binding =
+        dingo::bind<scope<shared>, storage<owner>, dependencies<a&>>;
+    using source = dingo::bindings<a_binding, b_binding, owner_binding>;
+    using graph = static_graph<source>;
+
+    static_assert(source::type::valid);
+    static_assert(graph::resolvable);
+    static_assert(!graph::acyclic);
+    static_assert(graph::contains_cycle);
+    static_assert(std::is_void_v<typename graph::topological_bindings>);
+    static_assert(detail::static_binding_resolvable_v<
+                  typename source::type::template binding<owner>,
+                  typename source::type>);
+}
+
+TEST(static_graph_test,
+     rejects_cycles_when_any_cycle_binding_is_not_shared_cyclical) {
+    struct a {};
+    struct b {};
+
+    using a_binding =
+        dingo::bind<scope<shared_cyclical>, storage<a>, dependencies<b&>>;
+    using b_binding = dingo::bind<scope<shared>, storage<b>, dependencies<a&>>;
+    using source = dingo::bindings<a_binding, b_binding>;
+    using graph = static_graph<source>;
+
+    static_assert(source::type::valid);
+    static_assert(!graph::resolvable);
+    static_assert(!graph::acyclic);
+    static_assert(
+        !detail::static_binding_resolvable_v<
+            typename source::type::template binding<a>, typename source::type>);
 }
 
 TEST(static_graph_test,
@@ -118,14 +164,16 @@ TEST(static_graph_test,
 
     using a_binding =
         dingo::bind<scope<shared>, storage<a>, dependencies<b&, runtime_only&>>;
-    using b_binding =
-        dingo::bind<scope<shared>, storage<b>, dependencies<a&>>;
+    using b_binding = dingo::bind<scope<shared>, storage<b>, dependencies<a&>>;
     using source = dingo::bindings<a_binding, b_binding>;
     using traits = detail::execution_traits<typename source::type, true>;
 
     static_assert(source::type::valid);
     static_assert(
         !detail::graph_analysis<typename source::type, true>::acyclic);
+    static_assert(
+        !detail::graph_analysis<typename source::type, true>::resolvable);
+    static_assert(!traits::resolvable);
     static_assert(!traits::acyclic);
 }
 
@@ -143,7 +191,8 @@ TEST(static_execution_traits_test,
         dingo::bind<scope<unique>, storage<leaf>>,
         dingo::bind<scope<unique>, storage<middle>, dependencies<leaf&>>,
         dingo::bind<scope<unique>, storage<root>, dependencies<middle&>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_preserved_closure_depth == 0);
@@ -164,7 +213,8 @@ TEST(static_execution_traits_test,
         dingo::bind<scope<unique>, storage<left>>,
         dingo::bind<scope<unique>, storage<right>>,
         dingo::bind<scope<unique>, storage<root>, dependencies<left&, right&>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_temporary_slots == 3);
@@ -227,10 +277,9 @@ TEST(static_execution_traits_test,
                   0);
     static_assert(shared_handle_storage::static_conversion_destructible_slots ==
                   0);
-    static_assert(
-        shared_handle_storage::static_conversion_temporary_size == 0);
-    static_assert(
-        shared_handle_storage::static_conversion_temporary_align == 0);
+    static_assert(shared_handle_storage::static_conversion_temporary_size == 0);
+    static_assert(shared_handle_storage::static_conversion_temporary_align ==
+                  0);
 }
 
 TEST(static_execution_traits_test,
@@ -251,8 +300,9 @@ TEST(static_execution_traits_test,
         std::is_base_of_v<detail::context_closure_base, partial_closure>);
 }
 
-TEST(static_execution_traits_test,
-     preserved_closure_depth_counts_preserving_bindings_across_non_preserving_edges) {
+TEST(
+    static_execution_traits_test,
+    preserved_closure_depth_counts_preserving_bindings_across_non_preserving_edges) {
     struct config {};
     struct transient_service {
         explicit transient_service(config&) {}
@@ -267,10 +317,12 @@ TEST(static_execution_traits_test,
     using source = dingo::bindings<
         dingo::bind<scope<shared>, storage<config>>,
         dingo::bind<scope<unique>, storage<transient_service>,
-             dependencies<config&>>,
-        dingo::bind<scope<unique>, storage<leaf>, dependencies<transient_service&>>,
+                    dependencies<config&>>,
+        dingo::bind<scope<unique>, storage<leaf>,
+                    dependencies<transient_service&>>,
         dingo::bind<scope<shared>, storage<shared_leaf>, dependencies<leaf&>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_preserved_closure_depth == 2);
@@ -284,13 +336,15 @@ TEST(static_execution_traits_test,
 
     using source = dingo::bindings<
         dingo::bind<scope<unique>, storage<std::shared_ptr<payload>>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_preserved_closure_depth == 0);
     static_assert(static_traits::max_destructible_slots == 1);
     static_assert(static_traits::max_temporary_slots == 1);
-    static_assert(static_traits::max_temporary_size >= sizeof(std::shared_ptr<payload>));
+    static_assert(static_traits::max_temporary_size >=
+                  sizeof(std::shared_ptr<payload>));
     static_assert(static_traits::max_temporary_align >=
                   alignof(std::shared_ptr<payload>));
 }
@@ -301,14 +355,17 @@ TEST(static_execution_traits_test,
         ~payload() {}
     };
 
-    using source = dingo::bindings<dingo::bind<scope<unique>, storage<payload>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using source =
+        dingo::bindings<dingo::bind<scope<unique>, storage<payload>>>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_preserved_closure_depth == 0);
     static_assert(static_traits::max_temporary_slots == 1);
     static_assert(static_traits::max_destructible_slots == 1);
-    static_assert(static_traits::max_temporary_size >= sizeof(std::optional<payload>));
+    static_assert(static_traits::max_temporary_size >=
+                  sizeof(std::optional<payload>));
     static_assert(static_traits::max_temporary_align >=
                   alignof(std::optional<payload>));
 }
@@ -317,8 +374,10 @@ TEST(static_execution_traits_test,
      shared_cyclical_paths_account_for_rollback_temporary_slots) {
     struct node {};
 
-    using source = dingo::bindings<dingo::bind<scope<shared_cyclical>, storage<node>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+    using source =
+        dingo::bindings<dingo::bind<scope<shared_cyclical>, storage<node>>>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_preserved_closure_depth == 0);
@@ -328,8 +387,9 @@ TEST(static_execution_traits_test,
     static_assert(static_traits::max_temporary_align >= alignof(void*));
 }
 
-TEST(static_execution_traits_test,
-     destructible_slots_follow_non_trivial_dependency_requests_along_static_paths) {
+TEST(
+    static_execution_traits_test,
+    destructible_slots_follow_non_trivial_dependency_requests_along_static_paths) {
     struct config {
         virtual ~config() = default;
     };
@@ -345,14 +405,17 @@ TEST(static_execution_traits_test,
     using source = dingo::bindings<
         dingo::bind<scope<shared>, storage<config>>,
         dingo::bind<scope<unique>, storage<payload>, dependencies<config&>>,
-        dingo::bind<scope<unique>, storage<service>,
-             dependencies<std::shared_ptr<payload>, std::optional<payload>>>>;
-    using static_traits = detail::static_execution_traits<typename source::type>;
+        dingo::bind<
+            scope<unique>, storage<service>,
+            dependencies<std::shared_ptr<payload>, std::optional<payload>>>>;
+    using static_traits =
+        detail::static_execution_traits<typename source::type>;
 
     static_assert(static_traits::acyclic);
     static_assert(static_traits::max_destructible_slots == 3);
     static_assert(static_traits::max_temporary_slots == 3);
-    static_assert(static_traits::max_temporary_size >= sizeof(std::optional<payload>));
+    static_assert(static_traits::max_temporary_size >=
+                  sizeof(std::optional<payload>));
     static_assert(static_traits::max_temporary_align >=
                   alignof(std::optional<payload>));
 }
@@ -367,11 +430,11 @@ TEST(static_graph_test, annotated_bindings_reuse_compile_time_bindings_lookup) {
 
     using config_binding =
         dingo::bind<scope<shared>, storage<config>,
-             interfaces<annotated<config, config_tag>>>;
+                    interfaces<annotated<config, config_tag>>>;
     using service_binding =
         dingo::bind<scope<unique>, storage<service>,
-             interfaces<annotated<service, service_tag>>,
-             dependencies<annotated<config&, config_tag>>>;
+                    interfaces<annotated<service, service_tag>>,
+                    dependencies<annotated<config&, config_tag>>>;
     using source = dingo::bindings<config_binding, service_binding>;
     using graph = static_graph<source>;
 

--- a/test/registration/static_bindings_source.cpp
+++ b/test/registration/static_bindings_source.cpp
@@ -5,12 +5,17 @@
 // SPDX-License-Identifier: MIT
 //
 
-#include <dingo/static/registry.h>
+#include <dingo/container.h>
 #include <dingo/registration/constructor.h>
+#include <dingo/static/registry.h>
+#include <dingo/static_container.h>
 #include <dingo/storage/shared.h>
+#include <dingo/storage/shared_cyclical.h>
 #include <dingo/storage/unique.h>
 
 #include <gtest/gtest.h>
+
+#include <memory>
 
 using namespace dingo;
 
@@ -25,24 +30,28 @@ TEST(static_bindings_source_test, exposes_models_and_dependency_bindings) {
 
     using config_binding = dingo::bind<scope<shared>, storage<config>>;
     using service_binding =
-        dingo::bind<scope<unique>, storage<service>, interfaces<service_interface>,
-                    dependencies<config&>>;
+        dingo::bind<scope<unique>, storage<service>,
+                    interfaces<service_interface>, dependencies<config&>>;
     using source = dingo::bindings<config_binding, service_binding>;
     using registry_type = typename source::type;
 
     static_assert(registry_type::valid);
     static_assert(std::is_same_v<typename registry_type::registration_types,
                                  type_list<config_binding, service_binding>>);
-    static_assert(std::is_same_v<typename registry_type::model<config>::registration_type,
-                                 config_binding>);
     static_assert(
-        std::is_same_v<typename registry_type::model<service_interface>::registration_type,
-                       service_binding>);
-    static_assert(std::is_same_v<typename registry_type::dependencies<service_interface>,
-                                 type_list<config&>>);
+        std::is_same_v<typename registry_type::model<config>::registration_type,
+                       config_binding>);
     static_assert(
-        std::is_same_v<typename registry_type::dependency_bindings<service_interface>,
-                       type_list<typename registry_type::binding<config>>>);
+        std::is_same_v<
+            typename registry_type::model<service_interface>::registration_type,
+            service_binding>);
+    static_assert(
+        std::is_same_v<typename registry_type::dependencies<service_interface>,
+                       type_list<config&>>);
+    static_assert(
+        std::is_same_v<
+            typename registry_type::dependency_bindings<service_interface>,
+            type_list<typename registry_type::binding<config>>>);
 }
 
 TEST(static_bindings_source_test, zero_argument_detected_constructor_is_known) {
@@ -54,11 +63,13 @@ TEST(static_bindings_source_test, zero_argument_detected_constructor_is_known) {
     static_assert(registry_type::valid);
     static_assert(std::is_same_v<typename registry_type::dependencies<config>,
                                  type_list<>>);
-    static_assert(std::is_same_v<typename registry_type::dependency_bindings<config>,
-                                 type_list<>>);
+    static_assert(
+        std::is_same_v<typename registry_type::dependency_bindings<config>,
+                       type_list<>>);
 }
 
-TEST(static_bindings_source_test, constructor_typedef_bindings_reuse_detected_dependencies) {
+TEST(static_bindings_source_test,
+     constructor_typedef_bindings_reuse_detected_dependencies) {
     struct config {};
     struct service {
         DINGO_CONSTRUCTOR(service(config&)) {}
@@ -85,13 +96,15 @@ TEST(static_bindings_source_test,
         service(config&, logger&) {}
     };
 
-    using source = dingo::bindings<dingo::bind<scope<shared>, storage<config>>,
-                                   dingo::bind<scope<shared>, storage<logger>>,
-                                   dingo::bind<scope<unique>, storage<service>>>;
+    using source =
+        dingo::bindings<dingo::bind<scope<shared>, storage<config>>,
+                        dingo::bind<scope<shared>, storage<logger>>,
+                        dingo::bind<scope<unique>, storage<service>>>;
     using registry_type = typename source::type;
 
     static_assert(registry_type::valid);
-    static_assert(std::is_same_v<typename registry_type::dependencies<service>, void>);
+    static_assert(
+        std::is_same_v<typename registry_type::dependencies<service>, void>);
     static_assert(
         std::is_same_v<typename registry_type::dependency_bindings<service>,
                        type_list<typename registry_type::binding<config>,
@@ -111,15 +124,16 @@ TEST(static_bindings_source_test,
     using registry_type = typename source::type;
 
     static_assert(registry_type::valid);
-    static_assert(std::is_same_v<typename registry_type::dependencies<service>,
-                                 void>);
+    static_assert(
+        std::is_same_v<typename registry_type::dependencies<service>, void>);
     static_assert(
         std::is_same_v<typename registry_type::dependency_bindings<service>,
                        type_list<typename registry_type::binding<config>,
                                  typename registry_type::binding<config>>>);
 }
 
-TEST(static_bindings_source_test, annotated_dependencies_normalize_to_annotated_interfaces) {
+TEST(static_bindings_source_test,
+     annotated_dependencies_normalize_to_annotated_interfaces) {
     struct service_tag {};
     struct config_tag {};
     struct config {};
@@ -138,17 +152,17 @@ TEST(static_bindings_source_test, annotated_dependencies_normalize_to_annotated_
     using registry_type = typename source::type;
 
     static_assert(registry_type::valid);
-    static_assert(
-        std::is_same_v<typename registry_type::dependencies<annotated<service, service_tag>>,
-                       type_list<annotated<config&, config_tag>>>);
-    static_assert(
-        std::is_same_v<typename registry_type::dependency_bindings<
-                           annotated<service&, service_tag>>,
-                       type_list<typename registry_type::binding<
-                           annotated<config, config_tag>>>>);
+    static_assert(std::is_same_v<typename registry_type::dependencies<
+                                     annotated<service, service_tag>>,
+                                 type_list<annotated<config&, config_tag>>>);
+    static_assert(std::is_same_v<typename registry_type::dependency_bindings<
+                                     annotated<service&, service_tag>>,
+                                 type_list<typename registry_type::binding<
+                                     annotated<config, config_tag>>>>);
 }
 
-TEST(static_bindings_source_test, supports_multibindings_and_keyed_multibindings) {
+TEST(static_bindings_source_test,
+     supports_multibindings_and_keyed_multibindings) {
     struct first_key : std::integral_constant<int, 0> {};
     struct second_key : std::integral_constant<int, 1> {};
     struct service_interface {
@@ -159,34 +173,36 @@ TEST(static_bindings_source_test, supports_multibindings_and_keyed_multibindings
     struct service_c : service_interface {};
 
     using first_binding =
-        dingo::bind<scope<shared>, storage<service_a>, interfaces<service_interface>,
-                    key<first_key>>;
+        dingo::bind<scope<shared>, storage<service_a>,
+                    interfaces<service_interface>, key<first_key>>;
     using second_binding =
-        dingo::bind<scope<shared>, storage<service_b>, interfaces<service_interface>,
-                    key<first_key>>;
+        dingo::bind<scope<shared>, storage<service_b>,
+                    interfaces<service_interface>, key<first_key>>;
     using third_binding =
-        dingo::bind<scope<shared>, storage<service_c>, interfaces<service_interface>,
-                    key<second_key>>;
-    using source = dingo::bindings<first_binding, second_binding, third_binding>;
+        dingo::bind<scope<shared>, storage<service_c>,
+                    interfaces<service_interface>, key<second_key>>;
+    using source =
+        dingo::bindings<first_binding, second_binding, third_binding>;
     using registry_type = typename source::type;
 
     static_assert(registry_type::valid);
-    static_assert(type_list_size_v<
-                      typename registry_type::template bindings<service_interface>> == 3);
+    static_assert(
+        type_list_size_v<
+            typename registry_type::template bindings<service_interface>> == 3);
     static_assert(std::is_void_v<
                   typename registry_type::template binding<service_interface>>);
-    static_assert(type_list_size_v<
-                      typename registry_type::template bindings<service_interface,
-                                                               first_key>> == 2);
+    static_assert(type_list_size_v<typename registry_type::template bindings<
+                      service_interface, first_key>> == 2);
     static_assert(type_list_size_v<typename registry_type::template bindings<
                       service_interface, second_key>> == 1);
-    static_assert(std::is_void_v<
-                  typename registry_type::template binding<service_interface, first_key>>);
-    static_assert(!std::is_void_v<
-                  typename registry_type::template binding<service_interface, second_key>>);
+    static_assert(std::is_void_v<typename registry_type::template binding<
+                      service_interface, first_key>>);
+    static_assert(!std::is_void_v<typename registry_type::template binding<
+                      service_interface, second_key>>);
 }
 
-TEST(static_bindings_source_test, keyed_dependencies_resolve_against_matching_keyed_bindings) {
+TEST(static_bindings_source_test,
+     keyed_dependencies_resolve_against_matching_keyed_bindings) {
     struct first_key : std::integral_constant<int, 0> {};
     struct second_key : std::integral_constant<int, 1> {};
     struct config {};
@@ -212,7 +228,64 @@ TEST(static_bindings_source_test, keyed_dependencies_resolve_against_matching_ke
         std::is_same_v<typename registry_type::dependency_bindings<service>,
                        type_list<typename registry_type::template binding<
                            keyed<config, first_key>>>>);
-    static_assert(std::is_same_v<
-                  typename registry_type::template binding<keyed<config, first_key>>,
-                  typename registry_type::template binding<config, first_key>>);
+    static_assert(
+        std::is_same_v<
+            typename registry_type::template binding<keyed<config, first_key>>,
+            typename registry_type::template binding<config, first_key>>);
+}
+
+TEST(static_bindings_source_test,
+     static_container_resolves_shared_cyclical_bindings) {
+    struct b;
+    struct a {
+        explicit a(b& init_dependency) : dependency(&init_dependency) {}
+        b* dependency;
+    };
+    struct b {
+        explicit b(a& init_dependency) : dependency(&init_dependency) {}
+        a* dependency;
+    };
+
+    using source = dingo::bindings<
+        dingo::bind<scope<shared_cyclical>, storage<a>, dependencies<b&>>,
+        dingo::bind<scope<shared_cyclical>, storage<b>, dependencies<a&>>>;
+
+    dingo::static_container<source> container;
+    auto& instance = container.resolve<a&>();
+
+    EXPECT_EQ(instance.dependency->dependency, &instance);
+    EXPECT_EQ(&container.resolve<a&>(), &instance);
+}
+
+TEST(static_bindings_source_test,
+     container_resolves_static_shared_cyclical_interface_handles) {
+    struct b_interface {
+        virtual ~b_interface() = default;
+    };
+    struct b;
+    struct a {
+        explicit a(b_interface& init_dependency)
+            : dependency(&init_dependency) {}
+        b_interface* dependency;
+    };
+    struct b : b_interface {
+        explicit b(a& init_dependency) : dependency(&init_dependency) {}
+        a* dependency;
+    };
+
+    using source = dingo::bindings<
+        dingo::bind<scope<shared_cyclical>, storage<a>,
+                    dependencies<b_interface&>>,
+        dingo::bind<scope<shared_cyclical>, storage<std::shared_ptr<b>>,
+                    interfaces<b_interface>, dependencies<a&>>>;
+
+    dingo::container<source> container;
+    auto& instance = container.resolve<a&>();
+    auto& interface = container.resolve<b_interface&>();
+    auto& b_instance = static_cast<b&>(interface);
+
+    EXPECT_EQ(instance.dependency, &interface);
+    EXPECT_EQ(b_instance.dependency, &instance);
+    EXPECT_EQ(&container.resolve<a&>(), &instance);
+    EXPECT_EQ(&container.resolve<b_interface&>(), &interface);
 }

--- a/test/registration/static_bindings_source.cpp
+++ b/test/registration/static_bindings_source.cpp
@@ -281,11 +281,11 @@ TEST(static_bindings_source_test,
 
     dingo::container<source> container;
     auto& instance = container.resolve<a&>();
-    auto& interface = container.resolve<b_interface&>();
-    auto& b_instance = static_cast<b&>(interface);
+    auto& b_view = container.resolve<b_interface&>();
+    auto& b_instance = static_cast<b&>(b_view);
 
-    EXPECT_EQ(instance.dependency, &interface);
+    EXPECT_EQ(instance.dependency, &b_view);
     EXPECT_EQ(b_instance.dependency, &instance);
     EXPECT_EQ(&container.resolve<a&>(), &instance);
-    EXPECT_EQ(&container.resolve<b_interface&>(), &interface);
+    EXPECT_EQ(&container.resolve<b_interface&>(), &b_view);
 }


### PR DESCRIPTION
## Summary
- allow static binding graph cycles when every binding in the cycle uses shared_cyclical storage
- separate graph resolvability from literal acyclicity so cyclic graphs do not expose topological_bindings
- add unit, lit, generated matrix, and docs coverage for static shared_cyclical resolution

## Verification
- cmake --build build --target dingo_unit_test dingo_matrix_test
- ctest --test-dir build --output-on-failure
- CXX=clang++-19 DINGO_CXX_STD=20 uv run --locked lit -sv test/lit
- cmake --build build --target md-verify
- git diff --check

## Notes
- Cross-parent/child static cycles remain unsupported; parent lookup is a one-way fallback.