### PR TITLE
Fix recursion guard for parent-container same-type delegation

### DIFF
--- a/include/dingo/resolution/recursion_guard.h
+++ b/include/dingo/resolution/recursion_guard.h
@@ -16,14 +16,23 @@ template <typename T,
           bool DefaultConstructible = std::is_default_constructible_v<T>>
 struct recursion_guard {
   template <typename Context>
-  explicit recursion_guard(Context &context)
-      : frame_guard_(context.template track_type<T>()) {
+  explicit recursion_guard(Context &context, const void *binding)
+      : frame_guard_(context.template track_type<T>()), binding_(binding),
+        prev_(head_) {
     // Track the active type path first so recursion exceptions can report
-    // the full resolution chain, including the repeated type.
-    if (visited_) {
-      throw detail::make_type_recursion_exception<T>(context);
+    // the full resolution chain, including the repeated type. Recursion is
+    // keyed by the binding instance: re-entering the same binding on this
+    // thread is a cycle, while an independent resolution of the same type
+    // through a different binding (e.g. a factory delegating to another
+    // container, or a child overriding and wrapping a parent binding) is
+    // legitimate.
+    for (const recursion_guard *guard = prev_; guard != nullptr;
+         guard = guard->prev_) {
+      if (guard->binding_ == binding_) {
+        throw detail::make_type_recursion_exception<T>(context);
+      }
     }
-    visited_ = true;
+    head_ = this;
   }
 
   recursion_guard(const recursion_guard &) = delete;
@@ -31,23 +40,24 @@ struct recursion_guard {
   recursion_guard(recursion_guard &&) = delete;
   recursion_guard &operator=(recursion_guard &&) = delete;
 
-  ~recursion_guard() {
-    if (active_) {
-      visited_ = false;
-    }
-  }
+  ~recursion_guard() { head_ = prev_; }
 
 private:
   detail::resolving_frame frame_guard_;
-  bool active_ = true;
-  static thread_local bool visited_;
+  const void *binding_;
+  recursion_guard *prev_;
+  // Intrusive per-type stack of guards active on this thread; guards nest
+  // strictly LIFO with the resolution stack.
+  static thread_local recursion_guard *head_;
 };
 
 template <typename T, bool DefaultConstructible>
-thread_local bool recursion_guard<T, DefaultConstructible>::visited_ = false;
+thread_local recursion_guard<T, DefaultConstructible>
+    *recursion_guard<T, DefaultConstructible>::head_ = nullptr;
 
 template <typename T> struct recursion_guard<T, true> {
-  template <typename Context> explicit recursion_guard(Context &) {}
+  template <typename Context>
+  explicit recursion_guard(Context &, const void *) {}
 
   recursion_guard(const recursion_guard &) = delete;
   recursion_guard &operator=(const recursion_guard &) = delete;
@@ -58,11 +68,12 @@ template <typename T> struct recursion_guard<T, true> {
 template <typename T> class recursion_guard_wrapper {
 public:
   template <typename Context>
-  recursion_guard_wrapper(Context &context, bool enabled) {
+  recursion_guard_wrapper(Context &context, const void *binding, bool enabled) {
     if (enabled) {
-      // The wrapped recursion_guard owns a self-linking resolving_frame,
-      // so it must stay at a fixed address for the whole guarded scope.
-      new (&storage_) recursion_guard<T>(context);
+      // The wrapped recursion_guard owns a self-linking resolving_frame and
+      // links itself into the per-type guard stack, so it must stay at a
+      // fixed address for the whole guarded scope.
+      new (&storage_) recursion_guard<T>(context, binding);
       active_ = true;
     }
   }

--- a/include/dingo/runtime_container.h
+++ b/include/dingo/runtime_container.h
@@ -14,6 +14,87 @@
 
 namespace dingo {
 
+namespace detail {
+
+template <typename ParentContainer, typename Request, typename IdType,
+          typename = void>
+struct has_parent_key_value_lookup_definition : std::false_type {};
+
+template <typename ParentContainer, typename Request, typename IdType>
+struct has_parent_key_value_lookup_definition<
+    ParentContainer, Request, IdType,
+    std::void_t<typename ParentContainer::lookup_definition_type>>
+    : std::bool_constant<!std::is_void_v<selected_lookup_entry_t<
+          normalized_type_t<Request>, std::decay_t<IdType>,
+          normalize_lookup_definitions_t<
+              typename ParentContainer::lookup_definition_type>>>> {};
+
+template <typename ParentContainer, typename Request, typename IdType>
+inline constexpr bool has_parent_key_value_lookup_definition_v =
+    has_parent_key_value_lookup_definition<ParentContainer, Request,
+                                           IdType>::value;
+
+template <typename T>
+inline constexpr bool is_runtime_auto_constructible_dependency_v =
+    std::is_same_v<dependency_value_t<T>, std::decay_t<T>> &&
+    (!std::is_reference_v<T> ||
+     (std::is_lvalue_reference_v<T> &&
+      std::is_const_v<std::remove_reference_t<T>> &&
+      is_auto_constructible<std::decay_t<T>>::value));
+
+template <typename T, typename = void>
+struct has_static_registry_type : std::false_type {};
+
+template <typename T>
+struct has_static_registry_type<T,
+                                std::void_t<typename T::static_registry_type>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool has_static_registry_type_v =
+    has_static_registry_type<T>::value;
+
+template <typename ParentContainer, typename Request, typename IdType,
+          typename = void>
+struct has_parent_runtime_binding_status : std::false_type {};
+
+template <typename ParentContainer, typename Request, typename IdType>
+struct has_parent_runtime_binding_status<
+    ParentContainer, Request, IdType,
+    std::void_t<decltype(std::declval<ParentContainer &>()
+                             .template runtime_binding_status_for_id<Request>(
+                                 std::declval<IdType &>()))>> : std::true_type {
+};
+
+template <typename ParentContainer, typename Request, typename IdType>
+inline constexpr bool has_parent_runtime_binding_status_v =
+    has_parent_runtime_binding_status<ParentContainer, Request, IdType>::value;
+
+template <typename ParentContainer, typename Request, typename IdType>
+constexpr bool has_parent_lookup_for_id() {
+  if constexpr (is_none_v<std::decay_t<IdType>> || is_typed_key_v<IdType>) {
+    return true;
+  } else {
+    return has_parent_key_value_lookup_definition_v<ParentContainer, Request,
+                                                    IdType>;
+  }
+}
+
+template <typename Request, typename ParentContainer, typename IdType>
+bool should_resolve_missing_from_parent(ParentContainer &parent, IdType &id) {
+  if constexpr (is_runtime_auto_constructible_dependency_v<Request> &&
+                !has_static_registry_type_v<ParentContainer> &&
+                has_parent_runtime_binding_status_v<ParentContainer, Request,
+                                                    IdType>) {
+    return parent.template runtime_binding_status_for_id<Request>(id) !=
+           binding_selection_status::not_found;
+  } else {
+    return true;
+  }
+}
+
+} // namespace detail
+
 template <typename ContainerTraits = dynamic_container_traits,
           typename Allocator = typename ContainerTraits::allocator_type,
           typename ParentContainer = void>
@@ -74,6 +155,12 @@ public:
     }
   }
 
+  template <typename T, typename IdType>
+  detail::binding_selection_status runtime_binding_status_for_id(IdType &&id) {
+    return runtime_registry_.template binding_status_for_id<T>(
+        std::forward<IdType>(id));
+  }
+
   template <typename T, typename IdType = none_t,
             typename R = dependency_result_t<T>>
   R resolve(IdType &&id = IdType()) {
@@ -85,7 +172,12 @@ public:
     } else {
       if (parent_ && runtime_registry_.template binding_status_for_id<T>(id) ==
                          detail::binding_selection_status::not_found) {
-        return resolve_parent_request<T, R>(std::forward<IdType>(id));
+        if constexpr (detail::has_parent_lookup_for_id<parent_container_type, T,
+                                                       IdType>()) {
+          if (detail::should_resolve_missing_from_parent<T>(*parent_, id)) {
+            return resolve_parent_request<T, R>(std::forward<IdType>(id));
+          }
+        }
       }
     }
     return runtime_registry_.template resolve<T>(std::forward<IdType>(id));
@@ -97,6 +189,11 @@ public:
     if (parent_ &&
         runtime_registry_.template binding_status_for_id<T>(none_t{}) ==
             detail::binding_selection_status::not_found) {
+      none_t id;
+      if (!detail::should_resolve_missing_from_parent<T>(*parent_, id)) {
+        return runtime_registry_
+            .template resolve_request<T, RemoveRvalueReferences>(context);
+      }
       return parent_->template resolve<T, RemoveRvalueReferences>(context);
     }
     return runtime_registry_
@@ -115,6 +212,11 @@ public:
     if (parent_ &&
         runtime_registry_.template binding_status_for_id<T>(key_type<Key>{}) ==
             detail::binding_selection_status::not_found) {
+      key_type<Key> id;
+      if (!detail::should_resolve_missing_from_parent<T>(*parent_, id)) {
+        return runtime_registry_
+            .template resolve_request<T, RemoveRvalueReferences, Key>(context);
+      }
       return parent_->template resolve<T, RemoveRvalueReferences>(
           context, key_type<Key>{});
     }
@@ -130,8 +232,13 @@ public:
   R resolve(runtime_context &context, IdType &&id) {
     if (parent_ && runtime_registry_.template binding_status_for_id<T>(id) ==
                        detail::binding_selection_status::not_found) {
-      return parent_->template resolve<T, RemoveRvalueReferences>(
-          context, std::forward<IdType>(id));
+      if constexpr (detail::has_parent_lookup_for_id<parent_container_type, T,
+                                                     IdType>()) {
+        if (detail::should_resolve_missing_from_parent<T>(*parent_, id)) {
+          return parent_->template resolve<T, RemoveRvalueReferences>(
+              context, std::forward<IdType>(id));
+        }
+      }
     }
     return runtime_registry_.template resolve<T, RemoveRvalueReferences>(
         context, std::forward<IdType>(id));

--- a/include/dingo/storage/shared.h
+++ b/include/dingo/storage/shared.h
@@ -26,7 +26,7 @@ struct shared {};
 template <typename Type> struct storage_materialization_traits<shared, Type> {
   template <typename Leaf, typename Context, typename Storage>
   static auto make_guard(Context &context, const Storage &storage) {
-    return detail::recursion_guard_wrapper<Leaf>(context,
+    return detail::recursion_guard_wrapper<Leaf>(context, &storage,
                                                  !storage.is_resolved());
   }
 

--- a/include/dingo/storage/unique.h
+++ b/include/dingo/storage/unique.h
@@ -19,8 +19,8 @@ struct unique {};
 
 template <typename Type> struct storage_materialization_traits<unique, Type> {
   template <typename Leaf, typename Context, typename Storage>
-  static auto make_guard(Context &context, const Storage &) {
-    return detail::recursion_guard<Leaf>(context);
+  static auto make_guard(Context &context, const Storage &storage) {
+    return detail::recursion_guard<Leaf>(context, &storage);
   }
 
   template <typename Storage> static bool preserves_closure(const Storage &) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(dingo_unit_test
     container/dingo.cpp
     container/incomplete_resolve.cpp
     container/incomplete_resolve_fixture.cpp
+    container/parent_container_resolution.cpp
     factory/constructor_detection.cpp
     lookup/associative_backends.cpp
     lookup/lookup.cpp

--- a/test/container/parent_container_resolution.cpp
+++ b/test/container/parent_container_resolution.cpp
@@ -1,0 +1,367 @@
+//
+// This file is part of dingo project <https://github.com/romanpauk/dingo>
+//
+// See LICENSE for license and copyright information
+// SPDX-License-Identifier: MIT
+//
+
+#include <dingo/container.h>
+#include <dingo/factory/callable.h>
+#include <dingo/index/array.h>
+#include <dingo/storage/shared.h>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace dingo;
+
+namespace {
+
+// Models a process composed from runtime parent containers:
+//
+//   base (low-level services shared between channels)
+//    <- ch1 / ch2 (per-channel services and the channel itself)
+//    <- system (composition routed through ch1 / ch2)
+//
+struct process_api {
+  process_api() : marker(42) { ++instances; }
+  static int instances;
+  int marker;
+};
+int process_api::instances = 0;
+
+struct shared_api {
+  shared_api() { ++instances; }
+  static int instances;
+};
+int shared_api::instances = 0;
+
+struct channel_api {
+  explicit channel_api(int channel_id) : id(channel_id) { ++instances; }
+  static int instances;
+  int id;
+};
+int channel_api::instances = 0;
+
+struct channel {
+  channel(std::shared_ptr<shared_api> shared_dep,
+          std::shared_ptr<channel_api> local_dep,
+          std::shared_ptr<process_api> process_dep)
+      : shared(std::move(shared_dep)), local(std::move(local_dep)),
+        process(std::move(process_dep)) {}
+
+  std::shared_ptr<shared_api> shared;
+  std::shared_ptr<channel_api> local;
+  std::shared_ptr<process_api> process;
+};
+
+struct system_root {
+  system_root(std::vector<std::shared_ptr<channel>> channel_list,
+              std::shared_ptr<shared_api> shared_dep,
+              std::shared_ptr<process_api> process_dep)
+      : channels(std::move(channel_list)), shared(std::move(shared_dep)),
+        process(std::move(process_dep)) {}
+
+  std::vector<std::shared_ptr<channel>> channels;
+  std::shared_ptr<shared_api> shared;
+  std::shared_ptr<process_api> process;
+};
+
+struct system_container_traits : dynamic_container_traits {
+  using index_definition_type = dingo::indexes<
+      dingo::index<channel, std::size_t, dingo::index_type::array<2>>>;
+};
+
+struct system_channel_0_key {};
+struct system_channel_1_key {};
+
+struct tree_node_api {
+  tree_node_api(std::string node_name, int node_weight,
+                std::shared_ptr<tree_node_api> parent_node = {})
+      : name(std::move(node_name)), weight(node_weight),
+        parent(std::move(parent_node)) {}
+
+  int operation(int value) const {
+    if (parent == nullptr) {
+      return value + weight;
+    }
+    return parent->operation(value) + weight;
+  }
+
+  std::string path() const {
+    if (parent == nullptr) {
+      return name;
+    }
+    return parent->path() + "/" + name;
+  }
+
+  std::string name;
+  int weight;
+  std::shared_ptr<tree_node_api> parent;
+};
+
+struct channel_hierarchy {
+  channel_hierarchy() : system(&base), ch1(&base), ch2(&base) {
+    shared_api::instances = 0;
+    process_api::instances = 0;
+    channel_api::instances = 0;
+
+    base.register_type<scope<shared>, storage<std::shared_ptr<shared_api>>>();
+    base.register_type<scope<shared>, storage<std::shared_ptr<process_api>>>();
+
+    ch1.register_type<scope<shared>, storage<std::shared_ptr<channel_api>>>(
+        callable([] { return std::make_shared<channel_api>(1); }));
+    ch1.register_type<scope<shared>, storage<std::shared_ptr<channel>>>();
+
+    ch2.register_type<scope<shared>, storage<std::shared_ptr<channel_api>>>(
+        callable([] { return std::make_shared<channel_api>(2); }));
+    ch2.register_type<scope<shared>, storage<std::shared_ptr<channel>>>();
+  }
+
+  void register_system_composition() {
+    system
+        .register_indexed_type<scope<shared>, storage<std::shared_ptr<channel>>,
+                               interfaces<channel>, key<system_channel_0_key>>(
+            callable(
+                [this] { return ch1.resolve<std::shared_ptr<channel>>(); }),
+            std::size_t{0});
+    system
+        .register_indexed_type<scope<shared>, storage<std::shared_ptr<channel>>,
+                               interfaces<channel>, key<system_channel_1_key>>(
+            callable(
+                [this] { return ch2.resolve<std::shared_ptr<channel>>(); }),
+            std::size_t{1});
+    system.register_type<scope<shared>,
+                         storage<std::vector<std::shared_ptr<channel>>>>(
+        callable(
+            [](indexed<std::shared_ptr<channel>, key<std::size_t, 0>> first,
+               indexed<std::shared_ptr<channel>, key<std::size_t, 1>> second) {
+              std::shared_ptr<channel> first_channel = first;
+              std::shared_ptr<channel> second_channel = second;
+              return std::vector<std::shared_ptr<channel>>{
+                  std::move(first_channel), std::move(second_channel)};
+            }));
+    system
+        .register_type<scope<shared>, storage<std::shared_ptr<system_root>>>();
+  }
+
+  container<> base;
+  container<system_container_traits, system_container_traits::allocator_type,
+            container<>>
+      system;
+  container<> ch1;
+  container<> ch2;
+};
+
+TEST(parent_container_resolution_test,
+     base_shared_dependencies_are_used_by_system_and_channels) {
+  channel_hierarchy h;
+  h.register_system_composition();
+
+  auto resolved_system = h.system.resolve<std::shared_ptr<system_root>>();
+  auto c1 = resolved_system->channels[0];
+  auto c2 = resolved_system->channels[1];
+  auto base_shared = h.base.resolve<std::shared_ptr<shared_api>>();
+  auto base_process = h.base.resolve<std::shared_ptr<process_api>>();
+
+  ASSERT_EQ(resolved_system->shared, base_shared);
+  ASSERT_EQ(c1->shared, c2->shared);
+  ASSERT_EQ(c1->shared, base_shared);
+
+  ASSERT_EQ(resolved_system->process, base_process);
+  ASSERT_EQ(c1->process, c2->process);
+  ASSERT_EQ(c1->process, base_process);
+
+  ASSERT_EQ(shared_api::instances, 1);
+  ASSERT_EQ(process_api::instances, 1);
+}
+
+TEST(parent_container_resolution_test,
+     channels_use_only_their_own_local_binding_instances) {
+  channel_hierarchy h;
+
+  auto c1 = h.ch1.resolve<std::shared_ptr<channel>>();
+  auto c2 = h.ch2.resolve<std::shared_ptr<channel>>();
+
+  ASSERT_EQ(c1->local, h.ch1.resolve<std::shared_ptr<channel_api>>());
+  ASSERT_EQ(c2->local, h.ch2.resolve<std::shared_ptr<channel_api>>());
+  ASSERT_NE(c1->local, c2->local);
+  ASSERT_EQ(c1->local->id, 1);
+  ASSERT_EQ(c2->local->id, 2);
+  ASSERT_EQ(channel_api::instances, 2);
+
+  ASSERT_THROW(h.base.resolve<std::shared_ptr<channel_api>>(),
+               type_not_found_exception);
+  ASSERT_THROW(h.system.resolve<std::shared_ptr<channel_api>>(),
+               type_not_found_exception);
+}
+
+TEST(parent_container_resolution_test, channels_use_base_parent_dependency) {
+  channel_hierarchy h;
+
+  auto c1 = h.ch1.resolve<std::shared_ptr<channel>>();
+  auto c2 = h.ch2.resolve<std::shared_ptr<channel>>();
+
+  ASSERT_EQ(c1->process, c2->process);
+  ASSERT_EQ(c1->process->marker, 42);
+  ASSERT_EQ(c1->process, h.base.resolve<std::shared_ptr<process_api>>());
+  ASSERT_EQ(process_api::instances, 1);
+}
+
+TEST(parent_container_resolution_test,
+     children_resolve_shared_dependency_from_base) {
+  channel_hierarchy h;
+
+  auto from_ch1 = h.ch1.resolve<std::shared_ptr<shared_api>>();
+  auto from_ch2 = h.ch2.resolve<std::shared_ptr<shared_api>>();
+
+  ASSERT_EQ(from_ch1, from_ch2);
+  ASSERT_EQ(from_ch1, h.base.resolve<std::shared_ptr<shared_api>>());
+  ASSERT_EQ(shared_api::instances, 1);
+}
+
+// A factory registered in one container may delegate to another container.
+// The delegating resolution is not a cycle even when both resolutions run
+// on the same thread and request the same type: recursion is tracked per
+// binding, not per type.
+TEST(parent_container_resolution_test,
+     delegating_factory_returns_the_instance_shared_by_children) {
+  channel_hierarchy h;
+
+  h.system.register_type<scope<shared>, storage<std::shared_ptr<shared_api>>>(
+      callable([&base = h.base] {
+        return base.resolve<std::shared_ptr<shared_api>>();
+      }));
+
+  // Resolve through the delegating factory first, while nothing is cached.
+  auto from_system = h.system.resolve<std::shared_ptr<shared_api>>();
+  auto c1 = h.ch1.resolve<std::shared_ptr<channel>>();
+  auto c2 = h.ch2.resolve<std::shared_ptr<channel>>();
+
+  ASSERT_EQ(from_system, c1->shared);
+  ASSERT_EQ(from_system, c2->shared);
+  ASSERT_EQ(shared_api::instances, 1);
+}
+
+TEST(parent_container_resolution_test,
+     child_tree_node_binding_delegates_to_base_tree_node) {
+  channel_hierarchy h;
+
+  h.base.register_type<scope<shared>, storage<std::shared_ptr<tree_node_api>>>(
+      callable([] { return std::make_shared<tree_node_api>("base", 100); }));
+  h.ch1.register_type<scope<shared>, storage<std::shared_ptr<tree_node_api>>>(
+      callable([&base = h.base] {
+        return std::make_shared<tree_node_api>(
+            "ch1", 1, base.resolve<std::shared_ptr<tree_node_api>>());
+      }));
+
+  auto base_node = h.base.resolve<std::shared_ptr<tree_node_api>>();
+  auto ch1_node = h.ch1.resolve<std::shared_ptr<tree_node_api>>();
+  auto ch2_node = h.ch2.resolve<std::shared_ptr<tree_node_api>>();
+
+  ASSERT_NE(ch1_node, base_node);
+  ASSERT_EQ(ch1_node->parent, base_node);
+  ASSERT_EQ(ch2_node, base_node);
+  ASSERT_EQ(ch1_node, h.ch1.resolve<std::shared_ptr<tree_node_api>>());
+
+  ASSERT_EQ(base_node->path(), "base");
+  ASSERT_EQ(ch1_node->path(), "base/ch1");
+  ASSERT_EQ(base_node->operation(7), 107);
+  ASSERT_EQ(ch1_node->operation(7), 108);
+}
+
+TEST(parent_container_resolution_test,
+     system_bundles_channels_resolved_from_children) {
+  channel_hierarchy h;
+  h.register_system_composition();
+
+  auto resolved_system = h.system.resolve<std::shared_ptr<system_root>>();
+
+  ASSERT_EQ(resolved_system->channels.size(), 2u);
+  ASSERT_EQ(h.system.resolve<std::shared_ptr<channel>>(std::size_t{0}),
+            h.ch1.resolve<std::shared_ptr<channel>>());
+  ASSERT_EQ(h.system.resolve<std::shared_ptr<channel>>(std::size_t{1}),
+            h.ch2.resolve<std::shared_ptr<channel>>());
+  ASSERT_EQ(resolved_system->channels[0],
+            h.ch1.resolve<std::shared_ptr<channel>>());
+  ASSERT_EQ(resolved_system->channels[1],
+            h.ch2.resolve<std::shared_ptr<channel>>());
+  ASSERT_EQ(resolved_system->channels[0]->shared,
+            resolved_system->channels[1]->shared);
+  ASSERT_EQ(resolved_system->shared,
+            h.base.resolve<std::shared_ptr<shared_api>>());
+  ASSERT_EQ(resolved_system->channels[0]->shared, resolved_system->shared);
+  ASSERT_EQ(resolved_system->process,
+            h.base.resolve<std::shared_ptr<process_api>>());
+  ASSERT_EQ(resolved_system->channels[0]->process, resolved_system->process);
+  ASSERT_NE(resolved_system->channels[0]->local,
+            resolved_system->channels[1]->local);
+}
+
+struct value_api {
+  explicit value_api(int initial_value) : value(initial_value) {}
+  int value;
+};
+
+// A child container may override a parent binding with a factory that
+// decorates the parent's instance of the same type.
+TEST(parent_container_resolution_test,
+     child_binding_can_decorate_parent_binding) {
+  container<> parent;
+  parent.register_type<scope<shared>, storage<std::shared_ptr<value_api>>>(
+      callable([] { return std::make_shared<value_api>(10); }));
+
+  container<> child(&parent);
+  child.register_type<scope<shared>, storage<std::shared_ptr<value_api>>>(
+      callable([&parent] {
+        auto inner = parent.resolve<std::shared_ptr<value_api>>();
+        return std::make_shared<value_api>(inner->value + 1);
+      }));
+
+  ASSERT_EQ(child.resolve<std::shared_ptr<value_api>>()->value, 11);
+  ASSERT_EQ(parent.resolve<std::shared_ptr<value_api>>()->value, 10);
+}
+
+struct cyclic_b;
+struct cyclic_a {
+  explicit cyclic_a(std::shared_ptr<cyclic_b> dependency)
+      : b(std::move(dependency)) {}
+  std::shared_ptr<cyclic_b> b;
+};
+struct cyclic_b {
+  explicit cyclic_b(std::shared_ptr<cyclic_a> dependency)
+      : a(std::move(dependency)) {}
+  std::shared_ptr<cyclic_a> a;
+};
+
+TEST(parent_container_resolution_test,
+     recursion_within_a_container_is_detected) {
+  container<> c;
+  c.register_type<scope<shared>, storage<std::shared_ptr<cyclic_a>>>();
+  c.register_type<scope<shared>, storage<std::shared_ptr<cyclic_b>>>();
+
+  ASSERT_THROW(c.resolve<std::shared_ptr<cyclic_a>>(),
+               type_recursion_exception);
+}
+
+TEST(parent_container_resolution_test,
+     recursion_across_containers_is_detected) {
+  container<> first;
+  container<> second;
+  first.register_type<scope<shared>, storage<std::shared_ptr<value_api>>>(
+      callable(
+          [&second] { return second.resolve<std::shared_ptr<value_api>>(); }));
+  second.register_type<scope<shared>, storage<std::shared_ptr<value_api>>>(
+      callable(
+          [&first] { return first.resolve<std::shared_ptr<value_api>>(); }));
+
+  ASSERT_THROW(first.resolve<std::shared_ptr<value_api>>(),
+               type_recursion_exception);
+}
+
+} // namespace

--- a/test/container/parent_container_resolution.cpp
+++ b/test/container/parent_container_resolution.cpp
@@ -7,7 +7,6 @@
 
 #include <dingo/container.h>
 #include <dingo/factory/callable.h>
-#include <dingo/index/array.h>
 #include <dingo/storage/shared.h>
 
 #include <gtest/gtest.h>
@@ -73,12 +72,9 @@ struct system_root {
 };
 
 struct system_container_traits : dynamic_container_traits {
-  using index_definition_type = dingo::indexes<
-      dingo::index<channel, std::size_t, dingo::index_type::array<2>>>;
+  using lookup_definition_type = dingo::lookups<
+      dingo::associative<std::size_t, channel, dingo::one, dingo::array<2>>>;
 };
-
-struct system_channel_0_key {};
-struct system_channel_1_key {};
 
 struct tree_node_api {
   tree_node_api(std::string node_name, int node_weight,
@@ -105,6 +101,19 @@ struct tree_node_api {
   std::shared_ptr<tree_node_api> parent;
 };
 
+struct channel_dependency_pack {
+  std::shared_ptr<shared_api> shared;
+  std::shared_ptr<channel_api> local;
+  std::shared_ptr<process_api> process;
+};
+
+struct packed_channel {
+  explicit packed_channel(channel_dependency_pack channel_deps)
+      : deps(std::move(channel_deps)) {}
+
+  channel_dependency_pack deps;
+};
+
 struct channel_hierarchy {
   channel_hierarchy() : system(&base), ch1(&base), ch2(&base) {
     shared_api::instances = 0;
@@ -124,28 +133,24 @@ struct channel_hierarchy {
   }
 
   void register_system_composition() {
-    system
-        .register_indexed_type<scope<shared>, storage<std::shared_ptr<channel>>,
-                               interfaces<channel>, key<system_channel_0_key>>(
-            callable(
-                [this] { return ch1.resolve<std::shared_ptr<channel>>(); }),
-            std::size_t{0});
-    system
-        .register_indexed_type<scope<shared>, storage<std::shared_ptr<channel>>,
-                               interfaces<channel>, key<system_channel_1_key>>(
-            callable(
-                [this] { return ch2.resolve<std::shared_ptr<channel>>(); }),
-            std::size_t{1});
-    system.register_type<scope<shared>,
-                         storage<std::vector<std::shared_ptr<channel>>>>(
-        callable(
-            [](indexed<std::shared_ptr<channel>, key<std::size_t, 0>> first,
-               indexed<std::shared_ptr<channel>, key<std::size_t, 1>> second) {
-              std::shared_ptr<channel> first_channel = first;
-              std::shared_ptr<channel> second_channel = second;
-              return std::vector<std::shared_ptr<channel>>{
-                  std::move(first_channel), std::move(second_channel)};
-            }));
+    system.register_type<scope<shared>, storage<std::shared_ptr<channel>>,
+                         interfaces<channel>>(
+        callable([this] { return ch1.resolve<std::shared_ptr<channel>>(); }),
+        key_value{std::size_t{0}});
+    system.register_type<scope<shared>, storage<std::shared_ptr<channel>>,
+                         interfaces<channel>>(
+        callable([this] { return ch2.resolve<std::shared_ptr<channel>>(); }),
+        key_value{std::size_t{1}});
+    system.register_type<
+        scope<shared>, storage<std::vector<std::shared_ptr<channel>>>>(callable(
+        [](dependency<std::shared_ptr<channel>, key_type<std::size_t, 0>> first,
+           dependency<std::shared_ptr<channel>, key_type<std::size_t, 1>>
+               second) {
+          std::shared_ptr<channel> first_channel = first;
+          std::shared_ptr<channel> second_channel = second;
+          return std::vector<std::shared_ptr<channel>>{
+              std::move(first_channel), std::move(second_channel)};
+        }));
     system
         .register_type<scope<shared>, storage<std::shared_ptr<system_root>>>();
   }
@@ -273,6 +278,25 @@ TEST(parent_container_resolution_test,
   ASSERT_EQ(ch1_node->path(), "base/ch1");
   ASSERT_EQ(base_node->operation(7), 107);
   ASSERT_EQ(ch1_node->operation(7), 108);
+}
+
+TEST(parent_container_resolution_test,
+     auto_constructed_dependency_pack_uses_child_container) {
+  channel_hierarchy h;
+
+  h.ch1
+      .register_type<scope<shared>, storage<std::shared_ptr<packed_channel>>>();
+
+  auto resolved = h.ch1.resolve<std::shared_ptr<packed_channel>>();
+
+  ASSERT_EQ(resolved->deps.shared,
+            h.base.resolve<std::shared_ptr<shared_api>>());
+  ASSERT_EQ(resolved->deps.process,
+            h.base.resolve<std::shared_ptr<process_api>>());
+  ASSERT_EQ(resolved->deps.local,
+            h.ch1.resolve<std::shared_ptr<channel_api>>());
+  ASSERT_THROW(h.base.resolve<std::shared_ptr<channel_api>>(),
+               type_not_found_exception);
 }
 
 TEST(parent_container_resolution_test,


### PR DESCRIPTION
  ## Summary

  - Track runtime recursion by binding identity instead of only by requested type.
  - Allow child containers to resolve the same API type from a parent binding without being treated as cyclic.
  - Add parent-container tests for shared base dependencies, channel-local dependencies, indexed system composition, same-type parent delegation, and real cycle detection.

  ## Notes

  Draft because `feature/split` is expected to interfere. 